### PR TITLE
Fixed $getAttachments

### DIFF
--- a/package/functions/funcs/getAttachments.js
+++ b/package/functions/funcs/getAttachments.js
@@ -84,4 +84,4 @@ return {
     }
 
 }
-}
+// i fixed it 


### PR DESCRIPTION
i blame azu

## Type
- [x] Bug Fix: yeah
- [ ] Functions: \<Function Name>
- [ ] Callbacks: \<Callback Name>
- [ ] Handlers: \<Handler Type>
- [ ] Others: \______

Dependencies (Third Party Modules) needed: <Name | Github Link> (Maximum: 20MB~ size)

Want a credit? Discord tag or other social media link: <DiscordTag | OtherSocialMediaLink>

Referenced Issue: #NaN (Answer for an issue, if any)

## Description
Pull Request Description Here
fixed $getattachments