### PR TITLE
Added $NSFWtype[...]

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "prism-media": "^1.2.7",
     "segfault-handler": "^1.3.0",
     "workerpool": "^6.1.0",
-    "ws": "^7.4.4"
+    "ws": "^7.4.4",
+    "nsfwjs": "^2.4.0"
   },
   "engines": {
     "node": ">=12.11.0"

--- a/package/functions/funcs/NSFWtype.js
+++ b/package/functions/funcs/NSFWtype.js
@@ -1,0 +1,30 @@
+module.exports = async d => {
+    const code = d.command.code
+
+    const inside = d.unpack()
+	const err = d.inside(inside)
+
+	if (err) return d.error(err)
+const img = inside
+  
+nsfwjs.load()
+  .then(function (model) {
+    return {
+        code: code.replaceLast(`$NSFWtype${inside}`, model.classify(inside).deleteBrackets())
+    }
+  })
+
+  
+}
+/*
+Usage: $checkNSFW[Image URL]
+
+
+The library categorizes image probabilities in the following 5 classes:
+
+Drawing - safe for work drawings (including anime)
+Hentai - hentai and pornographic drawings
+Neutral - safe for work neutral images
+Porn - pornographic images, sexual acts
+Sexy - sexually explicit images, not pornography
+*/


### PR DESCRIPTION
## Type
- [x] Functions: \ $NSFWtype[Image-url]


Dependencies | Url | Size
- NSFWJS  | [Github Link](https://github.com/infinitered/nsfwjs) | 2.64 MB
 
Discord Tag: `Darkgoatie#6381`

## Description
Added $NSFWtype[Image-url]
Returns one of these:
Name     | Description
----------|-------------------------------------------
Drawing | safe for work drawings (including anime)
Hentai    | hentai and pornographic drawings
Neutral  | safe for work neutral images
Porn | pornographic images, sexual acts
Sexy | sexually explicit images, not pornography