### PR TITLE
Added $firstMessageID by Dynamic

### DIFF
--- a/package/functions/funcs/firstMessageID.js
+++ b/package/functions/funcs/firstMessageID.js
@@ -1,0 +1,29 @@
+module.exports = async (d) => {
+    const code = d.command.code
+
+    const inside = d.unpack()
+
+    if (inside.inside) {
+        const channelID = await d.client.channels.cache.get(inside.inside)
+
+        if (!channelID) return d.error(`:x: Invalid channel ID in \`$firstMessageID${inside}\``)
+        const fetchMessages = await channelID.messages.fetch({
+            after: 1,
+            limit: 1
+        });
+        const fmsg = fetchMessages.first();
+
+        return {
+            code: code.replaceLast(`$firstMessageID${inside}`, fmsg.id.removeBrackets())
+        }
+    } else if(!inside.inside) {
+        const fetchMessages = await d.message.channel.messages.fetch({
+            after: 1,
+            limit: 1
+        });
+        const fmsg = fetchMessages.first();
+        return {
+            code: code.replaceLast(`$firstMessageID`, fmsg.id.removeBrackets())
+        }
+    }
+}

--- a/package/functions/funcs/randomCase.js
+++ b/package/functions/funcs/randomCase.js
@@ -1,0 +1,30 @@
+module.exports = async (d) => {
+     const code = d.command.code;
+     const inside = d.unpack();
+     const err = d.inside(inside);
+     if (err) return d.error(err);
+
+     let option = inside.inside;
+     if (!option) return d.error(`:x: Missing text in \`$randomCase${inside}\``);
+     const regex = !/[^a-zA-Z0-9 ]+/g.test(option);
+     if (!regex) return d.error(`:x: Invalid text in \`$randomCase${inside}\``);
+     let Cases = [
+  String.prototype.toUpperCase,
+  String.prototype.toLowerCase
+]
+     let str = option.toString();
+     let l = str.length;
+     let result = '';
+     let a;
+     let b;
+     let c;
+
+  for (b = 0; b < l; b++) {
+    c = Number(Math.random() <= 0.5);
+    a = Cases[c];
+    result += a.call(str[b])
+  }
+  return {
+    code: d.command.code.replaceLast(`$randomCase${inside}`, result),
+  }
+}

--- a/package/functions/funcs/reverse.js
+++ b/package/functions/funcs/reverse.js
@@ -1,0 +1,16 @@
+module.exports = (d) => {
+    const code = d.command.code;
+    const inside = d.unpack();
+    const err = d.inside(inside);
+    if (err) return d.error(err);
+
+    let option = inside.inside;
+    if (!option) return d.error(`:x: Missing characters in \`$reverse${inside}\``);
+    
+    let string = option.toString();
+    let reverse = string.split("").reverse().join("")
+
+    return {
+        code: d.command.code.replaceLast(`$reverse${inside}`, reverse),
+    }
+}

--- a/package/functions/parser.js
+++ b/package/functions/parser.js
@@ -845,6 +845,7 @@ $spliceTextJoin[$userRoles;,  ; | ;\n;3]
   $bulk: "Holds data for the bulk delete command. (messageDeleteBulk callback);$bulk[bulkOption]",
   $editGuild: "A compact function to edit different server settings.;$editGuild[option;result;guildID (optional)]",
   $firstMessageID: "Returns First message's ID from the current channel or in given channel;$firstMessageID or $firstMessageID[channelID]",
-  $randomCase: "Generates the given text with Random cases;$randomCase[text]"
+  $randomCase: "Generates the given text with Random cases;$randomCase[text]",
+  $reverse: "Converts the given characters into reverse order;$reverse[text or characters]"
 };
 module.exports = Parser;

--- a/package/functions/parser.js
+++ b/package/functions/parser.js
@@ -843,6 +843,7 @@ $spliceTextJoin[$userRoles;,  ; | ;\n;3]
   $pinsUpdate: "Holds data for the channel the channel pins were updated in. (channelPinsUpdate callback);$pinsUpdate[pinsUpdateOption]",
   $webhookUpdate: "Holds data for the channel the webhook was updated in. (webhookUpdate callback);$webhookUpdate[webhookUpdateOption]",
   $bulk: "Holds data for the bulk delete command. (messageDeleteBulk callback);$bulk[bulkOption]",
-  $editGuild: "A compact function to edit different server settings.;$editGuild[option;result;guildID (optional)]"
+  $editGuild: "A compact function to edit different server settings.;$editGuild[option;result;guildID (optional)]",
+  $firstMessageID: "Returns First message's ID from the current channel or in given channel;$firstMessageID or $firstMessageID[channelID]"
 };
 module.exports = Parser;

--- a/package/functions/parser.js
+++ b/package/functions/parser.js
@@ -844,6 +844,7 @@ $spliceTextJoin[$userRoles;,  ; | ;\n;3]
   $webhookUpdate: "Holds data for the channel the webhook was updated in. (webhookUpdate callback);$webhookUpdate[webhookUpdateOption]",
   $bulk: "Holds data for the bulk delete command. (messageDeleteBulk callback);$bulk[bulkOption]",
   $editGuild: "A compact function to edit different server settings.;$editGuild[option;result;guildID (optional)]",
-  $firstMessageID: "Returns First message's ID from the current channel or in given channel;$firstMessageID or $firstMessageID[channelID]"
+  $firstMessageID: "Returns First message's ID from the current channel or in given channel;$firstMessageID or $firstMessageID[channelID]",
+  $randomCase: "Generates the given text with Random cases;$randomCase[text]"
 };
 module.exports = Parser;


### PR DESCRIPTION
## Type
- [ ] Bug Fix
- [x] Functions: $firstMessageID
- [ ] Callbacks:
- [ ] Handlers:
- [ ] Others:

Dependencies (Third Party Modules) needed: none

Want a credit? Discord tag or other social media link: Dynamic#0005

Referenced Issue: #118 

## Description
$firstMessageID or $firstMessageID[channelID] returns First message's ID from the current channel or in given channel.