### PR TITLE
Fixed findMember.js and added a new search option.

### DIFF
--- a/package/functions/funcs/findMember.js
+++ b/package/functions/funcs/findMember.js
@@ -26,7 +26,7 @@ module.exports = async (d) => {
   };
 
 function getMemberFromMention(mention) {
-    const matches = mention.match(/^<@!?(\d+)>$/);
+    const matches = mention.addBrackets().match(/^<@!?(\d+)>$/);
     if (!matches) return {id: "undefined"};
 	const id = matches[1];
 	return {id: d.message.guild.members.cache.get(id)};

--- a/package/functions/funcs/findMember.js
+++ b/package/functions/funcs/findMember.js
@@ -10,19 +10,25 @@ module.exports = async (d) => {
   const returnAuthor = inside.splits.length > 1 ? inside.splits.pop() : "yes";
   const option = inside.splits.join(";").trim() || d.message.channel.id; //#channel
 
-  const u =
+  let u =
     d.message.guild.members.cache.get(option) ||
     d.message.guild.members.cache.find(
       (m) =>
         m.user.tag.toLowerCase() === option.toLowerCase() ||
         m.user.username.toLowerCase() === option.toLowerCase() ||
-        m.displayName.toLowerCase() === option.toLowerCase()
-    ) ||
-    d.message.mentions.members.first() ||
+        m.displayName.toLowerCase() === option.toLowerCase() || m.user.username.toLowerCase().includes(option.toLowerCase()) || m.displayName.toLowerCase().includes(option.toLowerCase())
+    ) || 
     (await d.message.guild.members.fetch(option).catch(d.noop)) ||
     (returnAuthor === "yes" ? d.message.member : { id: "undefined" });
-
+   if(u.id === "undefined") u = getMemberFromMention(option);
   return {
     code: code.replaceLast(`$findMember${inside}`, u.id),
   };
+
+function getMemberFromMention(mention) {
+    const matches = mention.match(/^<@!?(\d+)>$/);
+    if (!matches) return {id: "undefined"};
+	const id = matches[1];
+	return {id: d.message.guild.members.cache.get(id)};
+}
 };


### PR DESCRIPTION
I saw that $findMember gets the id of the replied member whom u replied keeping mention on so i have fixed that issue and also added the new option in which it will return a matching name with the member so like if you want to search a user named `Epic Games` you can just do `$findMember[Epic;no]` and it would return that member if there is none others with the same starting name. I hope it would be good for many. Also i tested it many times but didn't found any bugs but if u find the bug please inform me.

## Type
- [ ] Bug Fix
- [x] Functions: \$findMember
- [ ] Callbacks: \<Callback Name>
- [ ] Handlers: \<Handler Type>
- [ ] Others: \______

Dependencies (Third Party Modules) needed: <Name | Github Link> (Maximum: 20MB~ size)

Want a credit? Discord tag or other social media link: Discord: `BEAST#0001`

Referenced Issue: #NaN (Answer for an issue, if any)

## Description
Pull Request Description Here