### PR TITLE
Fixed maxRam returning wrong info. The code i used returns accurate r…

### DIFF
--- a/package/functions/funcs/maxRam.js
+++ b/package/functions/funcs/maxRam.js
@@ -2,6 +2,6 @@ module.exports = async d => {
 	let ram = `${process.env.SERVER_MEMORY} MB`
 
 	return {
-		code: d.command.code.replaceLast(`$maxRam${d.unpack()}`, ram)
+		code: d.command.code.replaceLast(`$maxRam`, ram)
 	}
 }


### PR DESCRIPTION
You can try it and i have tested it many times and it does returns correct max ram that was allowed to your bot's container/server

## Type
- [x] Bug Fix
- [ ] Functions: $maxRam
- [ ] Callbacks: \<Callback Name>
- [ ] Handlers: \<Handler Type>
- [ ] Others: \______

Dependencies (Third Party Modules) needed: <Name | Github Link> (Maximum: 20MB~ size)

Want a credit? Discord tag or other social media link: `BEAST#0001`

Referenced Issue: #NaN (Answer for an issue, if any)

## Description
Pull Request Description Here
