### PR TITLE
Added $indexOfArg

### DIFF
--- a/package/functions/Funcs/util/indexOfArg.js
+++ b/package/functions/Funcs/util/indexOfArg.js
@@ -1,0 +1,12 @@
+module.exports = d => {
+    const data = d.util.openFunc(d)
+    if (data.err) return d.error(data.err)
+
+    const [string, query] = data.inside.splits
+
+    data.result = string.addBrackets().split(" ").indexOf(query.addBrackets()) + 1
+
+    return {
+        code: d.util.setCode(data)
+    }
+}


### PR DESCRIPTION
Like `$indexOf`, but instead of returning the character position, it returns the argument position.
Usage: `$indexOfArg[string;query]`