### PR TITLE
songinfo Position fix

### DIFF
--- a/package/Handler/LavaCommands.js
+++ b/package/Handler/LavaCommands.js
@@ -88,7 +88,8 @@ async function Main(d) {
             }
                 break;
             case "songinfo": {
-                const track = player.queue.at(Number(data[1]) - 1) || player.queue.current || player.queue.previous;
+                let track = player.queue.at(Number(data[1]) - 1) || player.queue.current;
+                if (!data[1] | Number(data[1]) - 1 < 0) track = player.queue.current;
                 if (track) {
                     const p = data[0];
                     if (p === "current_duration") {


### PR DESCRIPTION
Position fixed

## Type
- [ ] Bug Fix
- [ ] Functions: \<Function Name>
- [ ] Callbacks: \<Callback Name>
- [ ] Handlers: LavaCommands.js
- [ ] Others: \______

Dependencies (Third Party Modules) needed: 
Want a credit? Discord tag or other social media link: 

Referenced Issue: 

## Changelog
- Fixed "songinfo" method position when called without provided data or kept showing previous track when queue ended
