### PR TITLE
Add custom status to setStatus

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@akarui/aoi.db": "^1.0.0",
     "@akarui/structures": "^1.0.2",
-    "discord.js": "^14.12.1",
+    "discord.js": "^14.13.0",
     "undici": "^5.18.0"
   },
   "devDependencies": {

--- a/src/functions/client/setStatus.js
+++ b/src/functions/client/setStatus.js
@@ -4,14 +4,14 @@ module.exports = (d) => {
 
     const [name, type = "PLAYING", status = "online", url, afk = "false"] =
         data.inside.splits;
-
     try {
         d.client.user.setPresence({
             status: status,
             activities: [
                 {
                     name: name.addBrackets(),
-                    type: type === "PLAYING" ? 0 : type === "STREAMING" ? 1 : type === "LISTENING" ? 2 : type === "WATCHING" ? 3 : type === "COMPETING" ? 5 : 0,
+                    state: name.addBrackets(),
+                    type: type === "PLAYING" ? 0 : type === "STREAMING" ? 1 : type === "LISTENING" ? 2 : type === "WATCHING" ? 3 : type === "CUSTOM" ? 4 : type === "COMPETING" ? 5 : 0,
                     url: url?.addBrackets(),
                 },
             ],

--- a/src/functions/client/setStatus.js
+++ b/src/functions/client/setStatus.js
@@ -4,13 +4,15 @@ module.exports = (d) => {
 
     const [name, type = "PLAYING", status = "online", url, afk = "false"] =
         data.inside.splits;
+    const state = type === "CUSTOM" ? { state: name.addBrackets() } : {}
+    
     try {
         d.client.user.setPresence({
             status: status,
             activities: [
                 {
                     name: name.addBrackets(),
-                    state: name.addBrackets(),
+                    ...state,
                     type: type === "PLAYING" ? 0 : type === "STREAMING" ? 1 : type === "LISTENING" ? 2 : type === "WATCHING" ? 3 : type === "CUSTOM" ? 4 : type === "COMPETING" ? 5 : 0,
                     url: url?.addBrackets(),
                 },


### PR DESCRIPTION
## Type
- [ ] Bug Fix
- [x] Functions: setStatus
- [ ] Callbacks: -
- [ ] Handlers: -
- [ ] Others: \______


Want a credit? Discord tag or other social media link: <igorwastaken | https://github.com/apenasigordev>

## Description
[Discord recently added custom status support for bots.](https://discord.com/developers/docs/change-log#activity-state-for-bot-users) So, i added it on `setStatus` function.

### I haven't tested this feature in aoi.js.

Screenshots:
![SmartSelect_20230815_212524_Discord](https://github.com/AkaruiDevelopment/aoi.js/assets/80823011/7ab506d8-169b-421d-8cee-ecd3f88c3fd6)

