### PR TITLE
$hasAttachment and Disable Mentions

### DIFF
--- a/src/functions/event/interactionEdit.js
+++ b/src/functions/event/interactionEdit.js
@@ -10,18 +10,17 @@ module.exports = async d => {
 
     files = await d.util.parsers.FileParser(files);
 
-    allowedMentions = allowedMentions === "all" ? ["everyone", "users", "roles"] : allowedMentions?.split(",") || [];
+    allowedMentions = allowedMentions === "all" ? [ "everyone", "users", "roles" ] : (allowedMentions ? allowedMentions?.split(",") : []);
 
     await d.data.interaction?.editReply({
-            content: content.trim() === "" ? " " : content.addBrackets(),
-            embeds: embeds,
-            components: components,
-            files,
-            allowedMentions: {
-                parse: allowedMentions
-            }
+        content: content.trim() === "" ? " " : content.addBrackets(),
+        embeds: embeds,
+        components: components,
+        files,
+        allowedMentions: {
+            parse: allowedMentions
         }
-    ).catch(e => {
+    }).catch(e => {
         d.aoiError.fnError(d, 'custom', {}, 'Failed To Reply With Reason: ' + e)
     });
 

--- a/src/functions/event/interactionReply.js
+++ b/src/functions/event/interactionReply.js
@@ -10,7 +10,7 @@ module.exports = async d => {
 
     files = await d.util.parsers.FileParser(files);
 
-    allowedMentions = allowedMentions === "all" ? [ "everyone", "users", "roles" ] : allowedMentions?.split( "," ) || [];
+    allowedMentions = allowedMentions === "all" ? [ "everyone", "users", "roles" ] : (allowedMentions ? allowedMentions?.split(",") : []);
 
     await d.data.interaction?.reply({
         content: content.trim() === "" ? " " : content.addBrackets(),

--- a/src/functions/message/hasAttachment.js
+++ b/src/functions/message/hasAttachment.js
@@ -1,0 +1,17 @@
+module.exports = async (d) => {
+    const data = d.util.aoiFunc(d);
+
+    const [messageID = d.message?.id, channelID = d.channel?.id] = data.inside.splits;
+
+    const channel = await d.util.getChannel(d, channelID);
+    if (!channel) return d.aoiError.fnError(d, 'channel', {inside: data.inside});
+
+    const message = await d.util.getMessage(channel, messageID);
+    if (!message) return d.aoiError.fnError(d, 'message', {inside: data.inside});
+
+    data.result = message.attachments.size ? true : false;
+
+    return {
+        code: d.util.setCode(data)
+    }
+}


### PR DESCRIPTION
## Type
- [x] Bug Fix: `$interactionReply` `interactionEdit`
- [x] Functions: `$hasAttachment[messageID;channelID]`
- [ ] Callbacks: \<Callback Name>
- [ ] Handlers: \<Handler Type>
- [ ] Others: \______

Dependencies (Third Party Modules) needed: no

Want a credit? Discord tag or other social media link: no ty

Referenced Issue: #NaN (Answer for an issue, if any)

## Description
Added support to disable all mentions in interaction responses

Added `$hasAttachment` which works like `$hasEmbed`
