### PR TITLE
Add name option to $TextSplit And $SplitText functions

### DIFF
--- a/src/functions/misc/editTextSplitElement.js
+++ b/src/functions/misc/editTextSplitElement.js
@@ -2,7 +2,7 @@ module.exports = async (d) => {
     const data = d.util.aoiFunc(d);
     if (data.err) return d.error(data.err);
 
-    let [name, index, text] = data.inside.splits;
+    let [index, text, name = 'main'] = data.inside.splits;
     data.function = d.func;
     index = index - 1;
 

--- a/src/functions/misc/editTextSplitElement.js
+++ b/src/functions/misc/editTextSplitElement.js
@@ -2,7 +2,7 @@ module.exports = async (d) => {
     const data = d.util.aoiFunc(d);
     if (data.err) return d.error(data.err);
 
-    let [index, text] = data.inside.splits;
+    let [name, index, text] = data.inside.splits;
     data.function = d.func;
     index = index - 1;
 
@@ -14,7 +14,7 @@ module.exports = async (d) => {
             "Invalid Index Provided In",
         );
 
-    d.array[index] = text;
+    d.array[name][index] = text;
 
     return {
         code: d.util.setCode(data),

--- a/src/functions/misc/findTextSplitIndex.js
+++ b/src/functions/misc/findTextSplitIndex.js
@@ -2,9 +2,9 @@ module.exports = async d => {
     const data = d.util.aoiFunc(d);
     if (data.err) return d.error(data.err);
 
-    const [query] = data.inside.splits;
+    const [name, query] = data.inside.splits;
 
-    data.result = d.array.indexOf(query) + 1;
+    data.result = d.array[name].indexOf(query) + 1;
 
     return {
         code: d.util.setCode(data)

--- a/src/functions/misc/findTextSplitIndex.js
+++ b/src/functions/misc/findTextSplitIndex.js
@@ -2,7 +2,7 @@ module.exports = async d => {
     const data = d.util.aoiFunc(d);
     if (data.err) return d.error(data.err);
 
-    const [name, query] = data.inside.splits;
+    const [query, name = 'main'] = data.inside.splits;
 
     data.result = d.array[name].indexOf(query) + 1;
 

--- a/src/functions/misc/joinSplitText.js
+++ b/src/functions/misc/joinSplitText.js
@@ -2,7 +2,7 @@ module.exports = d => {
     const data = d.util.aoiFunc(d);
     if (data.err) return d.error(data.err);
 
-    const [name, sep = ' '] = data.inside.inside;
+    const [sep = ' ', name = 'main'] = data.inside.inside;
 
     data.result = d.array[name].join(sep.addBrackets());
 

--- a/src/functions/misc/joinSplitText.js
+++ b/src/functions/misc/joinSplitText.js
@@ -2,9 +2,9 @@ module.exports = d => {
     const data = d.util.aoiFunc(d);
     if (data.err) return d.error(data.err);
 
-    const sep = data.inside.inside;
+    const [name, sep = ' '] = data.inside.inside;
 
-    data.result = d.array.join(sep.addBrackets());
+    data.result = d.array[name].join(sep.addBrackets());
 
     return {
         code: d.util.setCode(data, false)

--- a/src/functions/misc/removeSplitTextElement.js
+++ b/src/functions/misc/removeSplitTextElement.js
@@ -2,7 +2,7 @@ module.exports = d => {
     const data = d.util.aoiFunc(d);
     if (data.err) return d.error(data.err);
 
-    const [name, ...elements] = data.inside.splits;
+    const [...elements, name = 'main'] = data.inside.splits;
 
     for (const element of elements) {
         const index = d.array[name].indexOf(element.addBrackets());

--- a/src/functions/misc/removeSplitTextElement.js
+++ b/src/functions/misc/removeSplitTextElement.js
@@ -2,13 +2,13 @@ module.exports = d => {
     const data = d.util.aoiFunc(d);
     if (data.err) return d.error(data.err);
 
-    const [...elements] = data.inside.splits;
+    const [name, ...elements] = data.inside.splits;
 
     for (const element of elements) {
-        const index = d.array.indexOf(element.addBrackets());
+        const index = d.array[name].indexOf(element.addBrackets());
 
         if (index !== -1) {
-            d.array.splice(index, 1);
+            d.array[name].splice(index, 1);
         }
     }
     d.data.array = d.array;

--- a/src/functions/misc/removeTextSplitElement.js
+++ b/src/functions/misc/removeTextSplitElement.js
@@ -2,7 +2,7 @@ module.exports = d => {
     const data = d.util.aoiFunc(d);
     if (data.err) return d.error(data.err);
 
-    const [name, element] = data.inside.splits;
+    const [element, name = 'main'] = data.inside.splits;
 
     const index = d.array[name].indexOf(element.addBrackets());
 

--- a/src/functions/misc/removeTextSplitElement.js
+++ b/src/functions/misc/removeTextSplitElement.js
@@ -2,12 +2,12 @@ module.exports = d => {
     const data = d.util.aoiFunc(d);
     if (data.err) return d.error(data.err);
 
-    const [element] = data.inside.splits;
+    const [name, element] = data.inside.splits;
 
-    const index = d.array.indexOf(element.addBrackets());
+    const index = d.array[name].indexOf(element.addBrackets());
 
     if (index !== -1) {
-        d.array.splice(index, 1);
+        d.array[name].splice(index, 1);
     }
 
     d.data.array = d.array;

--- a/src/functions/util/concatTextSplit.js
+++ b/src/functions/util/concatTextSplit.js
@@ -4,7 +4,7 @@ module.exports = async d => {
     const err = d.inside(inside);
     if (err) return d.error(err);
 
-    let [name, ...text] = inside.splits;
+    let [...text, name = 'main'] = inside.splits;
     text = text.map(x => x.addBrackets());
     d.array[name].concat(text)
 

--- a/src/functions/util/concatTextSplit.js
+++ b/src/functions/util/concatTextSplit.js
@@ -4,9 +4,9 @@ module.exports = async d => {
     const err = d.inside(inside);
     if (err) return d.error(err);
 
-    let [...text] = inside.splits;
+    let [name, ...text] = inside.splits;
     text = text.map(x => x.addBrackets());
-    d.array.concat(text)
+    d.array[name].concat(text)
 
     return {
         code: d.util.setCode({function: d.func, code, inside}),

--- a/src/functions/util/filterTextSplitElement.js
+++ b/src/functions/util/filterTextSplitElement.js
@@ -2,7 +2,7 @@ module.exports = async d => {
     const data = d.util.aoiFunc(d);
     if (data.err) return d.error(data.err);
 
-    let [name, query, type = "equal", separator = ","] = data.inside.splits;
+    let [query, type = "equal", separator = ",", name = 'main'] = data.inside.splits;
     if (!["equal", "starts", "ends", "includes"].includes(type)) return d.aoiError.fnError(d, "custom", {inside: data.inside}, `Invalid Type Provided In`);
 
     switch (type) {

--- a/src/functions/util/filterTextSplitElement.js
+++ b/src/functions/util/filterTextSplitElement.js
@@ -2,21 +2,21 @@ module.exports = async d => {
     const data = d.util.aoiFunc(d);
     if (data.err) return d.error(data.err);
 
-    let [query, type = "equal", separator = ","] = data.inside.splits;
+    let [name, query, type = "equal", separator = ","] = data.inside.splits;
     if (!["equal", "starts", "ends", "includes"].includes(type)) return d.aoiError.fnError(d, "custom", {inside: data.inside}, `Invalid Type Provided In`);
 
     switch (type) {
         case "equal" :
-            data.result = d.array.filter(x => x === query)
+            data.result = d.array[name].filter(x => x === query)
             break;
         case "starts":
-            data.result = d.array.filter(x => x.startsWith(query))
+            data.result = d.array[name].filter(x => x.startsWith(query))
             break;
         case "ends" :
-            data.result = d.array.filter(x => x.endsWith(query))
+            data.result = d.array[name].filter(x => x.endsWith(query))
             break;
         case "includes":
-            data.result = d.array.filter(x => x.includes(query))
+            data.result = d.array[name].filter(x => x.includes(query))
             break;
     }
 

--- a/src/functions/util/getTextSplitLength.js
+++ b/src/functions/util/getTextSplitLength.js
@@ -1,7 +1,10 @@
 module.exports = d => {
     const {code} = d.util.aoiFunc(d);
+    const inside = d.unpack();
+    
+    let [name] = inside.splits;
 
     return {
-        code: d.util.setCode({function: d.func, code, result: d.array.length})
+        code: d.util.setCode({function: d.func, code, result: d.array[name].length})
     }
 }

--- a/src/functions/util/getTextSplitLength.js
+++ b/src/functions/util/getTextSplitLength.js
@@ -2,7 +2,7 @@ module.exports = d => {
     const {code} = d.util.aoiFunc(d);
     const inside = d.unpack();
     
-    let [name] = inside.splits;
+    let [name = 'main'] = inside.splits;
 
     return {
         code: d.util.setCode({function: d.func, code, result: d.array[name].length})

--- a/src/functions/util/splitText.js
+++ b/src/functions/util/splitText.js
@@ -2,7 +2,7 @@ module.exports = d => {
     const data = d.util.aoiFunc(d);
     if (data.err) return d.error(data.err);
 
-    const [name, index] = data.inside.splits;
+    const [index, name = 'main'] = data.inside.splits;
 
     if (isNaN(index) || Number(index) < 1) return d.aoiError.fnError(d, 'custom', { inside: data.inside }, 'Invalid Index Provided In');
     if (!name) return d.aoiError.fnError(d, 'custom', { inside: data.inside }, 'Invalid Name Provided In');

--- a/src/functions/util/splitText.js
+++ b/src/functions/util/splitText.js
@@ -2,11 +2,12 @@ module.exports = d => {
     const data = d.util.aoiFunc(d);
     if (data.err) return d.error(data.err);
 
-    const [index] = data.inside.splits;
+    const [name, index] = data.inside.splits;
 
-    if (isNaN(index) || Number(index) < 1) return d.aoiError.fnError(d, 'custom', {inside: data.inside}, 'Invalid Index Provided In');
+    if (isNaN(index) || Number(index) < 1) return d.aoiError.fnError(d, 'custom', { inside: data.inside }, 'Invalid Index Provided In');
+    if (!name) return d.aoiError.fnError(d, 'custom', { inside: data.inside }, 'Invalid Name Provided In');
 
-    data.result = d.array[Number(index) - 1];
+    data.result = d.array[name][Number(index) - 1];
 
     return {
         code: d.util.setCode(data)

--- a/src/functions/util/textSplit.js
+++ b/src/functions/util/textSplit.js
@@ -1,7 +1,7 @@
 module.exports = d => {
     const data = d.util.aoiFunc(d);
 
-    let [name, text, sep = ' '] = data.inside.splits;
+    let [text, sep = ' ', name = 'main'] = data.inside.splits;
     if (!name) return d.aoiError.fnError(d, 'custom', { inside: data.inside }, 'Invalid Name Provided In');
 
     d.array[name] = text.addBrackets().split(sep.addBrackets());

--- a/src/functions/util/textSplit.js
+++ b/src/functions/util/textSplit.js
@@ -1,9 +1,10 @@
 module.exports = d => {
     const data = d.util.aoiFunc(d);
 
-    let [text, sep = ' '] = data.inside.splits;
+    let [name, text, sep = ' '] = data.inside.splits;
+    if (!name) return d.aoiError.fnError(d, 'custom', { inside: data.inside }, 'Invalid Name Provided In');
 
-    d.array = text.addBrackets().split(sep.addBrackets());
+    d.array[name] = text.addBrackets().split(sep.addBrackets());
     d.data.array = d.array;
 
     return {

--- a/src/functions/util/textSplitMap.js
+++ b/src/functions/util/textSplitMap.js
@@ -3,7 +3,7 @@ const Interpreter = require("../../core/interpreter.js");
 module.exports = async (d) => {
     const data = d.util.aoiFunc(d);
 
-    let [name, commands] = data.inside.splits;
+    let [commands, name = 'main'] = data.inside.splits;
     const content = [];
 
     if (

--- a/src/functions/util/textSplitMap.js
+++ b/src/functions/util/textSplitMap.js
@@ -3,7 +3,7 @@ const Interpreter = require("../../core/interpreter.js");
 module.exports = async (d) => {
     const data = d.util.aoiFunc(d);
 
-    let commands = data.inside.splits;
+    let [name, commands] = data.inside.splits;
     const content = [];
 
     if (
@@ -21,7 +21,7 @@ module.exports = async (d) => {
             "Invalid Awaited Command In",
         );
 
-    for (const a of d.array) {
+    for (const a of d.array[name]) {
         for (const command of commands) {
             const cmd = d.client.cmd.awaited.find(
                 (y) => y.name.toLowerCase() === command.trim().toLowerCase(),


### PR DESCRIPTION
## Type
- [ ] Bug Fix
- [ x] Functions: \$textSplit, $splitText
- [ ] Callbacks: \<Callback Name>
- [ ] Handlers: \<Handler Type>
- [ ] Others: \______

Dependencies (Third Party Modules) needed: <Name | Github Link> (Maximum: 20MB~ size)

Want a credit? Discord tag or other social media link: <DiscordTag | OtherSocialMediaLink>

Referenced Issue: #NaN (Answer for an issue, if any)

## Description
Add `name` option to `$textSplit` and `$splitText` to make more than one in cmd, and that could be useful and not use `$advancedTextSplit` many times in code which make it not readable if have more than one split.
