### PR TITLE
Update isValidHex.js

### DIFF
--- a/src/functions/util/isValidHex.js
+++ b/src/functions/util/isValidHex.js
@@ -3,9 +3,9 @@ module.exports = d => {
     if (data.err) return d.error(data.err);
 
     let [hex] = data.inside.splits;
-    hex = hex.addBrackets().replace('#', '');
-
-    data.result = isNaN(parseInt(hex, 16)) ? false : true;
+    const regex =  /^#?([0-9A-Fa-f]{3}){1,2}$/;
+    
+    data.result = regex.test(hex)
 
     return {
         code: d.util.setCode(data)


### PR DESCRIPTION
## Type
- [ ] Bug Fix
- [x] Functions: \<Function Name>
- [ ] Callbacks: \<Callback Name>
- [ ] Handlers: \<Handler Type>
- [ ] Others: \______

Dependencies (Third Party Modules) needed: #NaN
Want a credit? Discord tag or other social media link: <DiscordTag | OtherSocialMediaLink>

Referenced Issue: #NaN

## Description
Fixed $isValidHex to support only #<6/3char>/<6/3char>
Eg
$isValidHex[#ffffff] //true [fff, ffffff, #fff]
$isValidHex[80] // false

