### PR TITLE
createArray with JSON support

### DIFF
--- a/src/functions/createArray.js
+++ b/src/functions/createArray.js
@@ -1,14 +1,23 @@
 module.exports = async d => {
     const data = d.util.aoiFunc(d);
-		if(data.err) return d.error(data.err);
+                  if(data.err) return d.error(data.err);
+                  let [name, ...elements] = data.inside.splits;    
 
-		const [name,...elements] = data.inside.splits;
-		d.arrays[name] = elements;
-		d.data.arrays = d.arrays;
-		
-		return {
-			code: d.util.setCode(data),
-			arrays: d.arrays,
-			data:d.data,
-		}
+    if (elements[0]?.startsWith("[") && elements[0]?.endsWith("]")) {
+        const element = elements[0];
+        try {
+            elements = JSON.parse(element);
+        } catch (err) {
+            d.aoiError.fnError(d, "custom", {}, `${err}`); 
+        };
+    };
+
+                  d.arrays[name] = elements;
+                  d.data.arrays = d.arrays;
+
+                  return {
+                            code: d.util.setCode(data),
+                            arrays: d.arrays,
+                            data: d.data,
+                  }
 }


### PR DESCRIPTION
## Type
- [ ] Bug Fix: No
- [x] Functions: $createArray
- [ ] Callbacks: \<Callback Name>
- [ ] Handlers: \<Handler Type>
- [ ] Others: \______

Dependencies (Third Party Modules) needed:  N/A

Want a credit? Discord tag or other social media link: @nanotechpikachu

Referenced Issue: #NaN (Answer for an issue, if any)

## Description
The function support the earlier method of ";" and normal Array []
This will allow the use of `.push()` and other Array functions without resorting to djs if an Array is returned by API request or something.
