### PR TITLE
Improvements for httpRequest

### DIFF
--- a/src/functions/httpRequest.js
+++ b/src/functions/httpRequest.js
@@ -4,10 +4,17 @@ module.exports = async (d) => {
     const data = d.util.aoiFunc(d);
     if (data.err) return d.error(data.err);
 
-    let [url, method = 'get', body = '', property, error = 'default', ...header] =
-        data.inside.splits;
+    let [
+        url,
+        method = 'get',
+        body = '',
+        property,
+        error = 'default',
+        ...header
+    ] = data.inside.splits;
 
-    body = body?.trim() === '' ? undefined : body
+    body = body?.trim() === '' ? undefined : body;
+    
     let headers = {};
     if (header.length === 1) {
         try {
@@ -34,9 +41,15 @@ module.exports = async (d) => {
         });
 
         const responseBody = await response.text();
-        data.result = property
-            ? eval(`JSON.parse(responseBody)?.${property}`)
-            : responseBody;
+        const contentType = response.headers.get("content-type")?.split(/;/)[0];
+
+        if (property && /content(-|\s)?type/gi.test(property)) {
+            data.result = contentType;
+        } else if (property && contentType.includes("json")) {
+            data.result = eval(`JSON.parse(responseBody)?.${property}`)
+        } else {
+            data.result = responseBody;
+        }
     } catch (err) {
         console.error(err);
         if (error === 'default') {

--- a/src/functions/textTrim.js
+++ b/src/functions/textTrim.js
@@ -2,7 +2,9 @@ module.exports = d => {
     const data = d.util.aoiFunc(d);
 
     let [text] = data.inside.splits;
-    data.result = text.trim();
+    data.result = /\n/.test(text) 
+        ? text.split(/\n/).map(l => l.trim()).filter(l => l !== "").join("\n") 
+        : text.trim();
 
     return {
         code: d.util.setCode(data)


### PR DESCRIPTION
## Type
- [ ] Bug Fix
- [x] Functions: `$httpRequest`
- [ ] Callbacks: \<Callback Name>
- [ ] Handlers: \<Handler Type>
- [ ] Others: \______

Dependencies (Third Party Modules) needed: **None**

Want a credit? Discord tag or other social media link: @asayukiii

Referenced Issue: **#NaN**

## Description
Recently, I saw an user trying to find a way to check if a given URL belongs to a GIF image.
I started to think about that, there isn't a way to know the content type of the response.
This is why I made the changes in this PR, also, I made the JSON parsing a bit safer than before.
**I've tested the function using these references and worked as expected:**
### Test 1
Returning the whole API response
```yaml
$httpRequest[https://jsonplaceholder.typicode.com/todos/1;GET]
# Returns: { "userId": 1, "id": 1, "title": "delectus aut autem", "completed": false }
```
### Test 2
Returning a property from the API response (only if content-type is JSON)
```yaml
$httpRequest[https://jsonplaceholder.typicode.com/todos/1;GET;;userId]
# Returns: 1
```
### Test 3
Retrieving the content type of the API response
```yaml
$httpRequest[https://jsonplaceholder.typicode.com/todos/1;GET;;contentType]
# Returns: application/json
```
### Test 4
Fetching an image from Discord
```yaml
$httpRequest[https://cdn.discordapp.com/attachments/1186843739369513043/1263476068430385272/MenYou-1.gif?ex=66bb54c8&is=66ba0348&hm=2f54b2e187fe2ccb52f94507670cf1bd095dbcc2d9b7d915a3233e6a3ebbc387&;get;;contentType]
# Returns: image/gif
```
### Test 5
Fetching an HTML
```yaml
$httpRequest[https://www.quora.com/Why-do-furries-exist;get;;contentType]
# Returns: text/html

$httpRequest[https://www.quora.com/Why-do-furries-exist;get]
# Returns: <!DOCTYPE html><html lang='en' dir='ltr' style='padding: 0;...
```