### PR TITLE
V6 Macros

### DIFF
--- a/src/classes/AoiBase.js
+++ b/src/classes/AoiBase.js
@@ -11,6 +11,7 @@ const {
     EventstoFile
 } = require("../utils/Constants.js");
 const Database = require("./Database.js");
+const { MacrosManager } = require("./Macros.js");
 const CacheManager = require("./CacheManager.js");
 const { CommandManager } = require("./Commands.js");
 const { Group } = require("@aoijs/aoi.structures");
@@ -55,6 +56,7 @@ class BaseClient extends Client {
         this.cacheManager = new CacheManager(this);
 
         this.variableManager = new VariableManager(this);
+        this.macros = new MacrosManager();
 
         if (
             options.disableAoiDB !== true &&
@@ -117,6 +119,15 @@ class BaseClient extends Client {
     loadCommands(directory, debug = true) {
         const loader = new LoadCommands(this);
         loader.load(this.cmd, directory, debug);
+    }
+
+    /**
+     * Adds many macros to the manager.
+     * @param {import("..").MacroOptions[]} macros - The macros to be added.
+     * @returns {void}
+     */
+    macro(...macros) {
+        this.macros.addMany([...macros]);
     }
 
     status(...statuses) {

--- a/src/classes/Commands.js
+++ b/src/classes/Commands.js
@@ -1,13 +1,25 @@
+const { hasMacros, resolveMacros } = require("./Macros");
 const { Group } = require("@aoijs/aoi.structures");
 
 class Command {
+    /**
+     * Creates a new instance of the `Command` class.
+     * @param {import("..").BaseCommand} data - The command data.
+     * @param {import("..").AoiClient} client - The AoiClient instance.
+     */
     constructor(data = {}, client) {
-        this.__client__ = client;
-        if (typeof data.code === "string") {
-            this.code = data.code;
-        } else {
+        if (typeof data.code !== "string") {
             throw new TypeError(`Missing or invalid 'code' property in '${data.name}' command \n Path: '${data.__path__}'`);
         }
+
+        this.__client__ = client;
+        
+        if (hasMacros(client.macros.list(), data.code)) {
+            data.code = resolveMacros(client.macros.toArray(), data.code);
+        }
+
+        this.code = data.code;
+        
         Object.entries(data).forEach(([key, value]) => (this[key] = value));
         this.functions = this.serializeFunctions();
         this.codeLines = this.serializeCode();

--- a/src/classes/Macros.js
+++ b/src/classes/Macros.js
@@ -1,0 +1,109 @@
+class MacrosManager {
+    /**
+     * @type {Map<string, import("..").MacroOptions>}
+     */
+    cache = new Map();
+
+    /**
+     * Adds a macro to the manager.
+     * @param {import("..").MacroOptions} macro - The macro to be added.
+     * @returns {this}
+     */
+    add(macro) {
+        macro.name = macro.name.startsWith("#")
+            ? macro.name.slice(1)
+            : macro.name;
+
+        this.cache.set(macro.name, macro);
+
+        return this;
+    }
+
+    /**
+     * Adds many macros to the manager.
+     * @param {import("..").MacroOptions[]} macros - The macros to be added.
+     * @returns {this}
+     */
+    addMany(macros) {
+        for (const macro of macros) {
+            this.add(macro);
+        }
+        return this;
+    }
+
+    /**
+     * Get a macro.
+     * @param {string | ((macro: import("..").MacroOptions) => boolean)} name - The name of the macro.
+     * @returns {?import("..").MacroOptions}
+     */
+    get(name) {
+        if (typeof name === "string") return this.cache.get(name) || null;
+
+        return this.toArray().find(name) || null;
+    }
+
+    /**
+     * Return the list of cached macro names.
+     * @returns {string[]}
+     */
+    list() {
+        return [...this.cache.keys()];
+    }
+
+    /**
+     * Return an array of cached macros.
+     * @returns {import("..").MacroOptions[]}
+     */
+    toArray() {
+        return [...this.cache.values()];
+    }
+};
+
+/**
+ * Creates a pattern to match the cached macros.
+ * @param {string[]} names - The names of the macros.
+ * @returns {RegExp}
+ */
+function createMacrosPattern(names) {
+    return new RegExp(`#(${names.join("|")})`, "g");
+};
+
+/**
+ * Check whether the given code has macros inside.
+ * @param {string[]} names - The names of the cached macros.
+ * @param {string} code - The code to be tested.
+ * @returns {boolean}
+ */
+function hasMacros(names, code) {
+    return Array.isArray(code.match(createMacrosPattern(names)))
+};
+
+/**
+ * Resolve the macros in the command code with actual code.
+ * @param {import("..").MacroOptions[]} macros - The cached macros.
+ * @param {string} code - The code to be resolved.
+ * @returns {string}
+ */
+function resolveMacros(macros, code) {
+    const matchedMacros = [...new Set(code.match(createMacrosPattern(macros.map(m => m.name))) ?? [])];
+    let newCode = code;
+
+    for (const matchedMacro of matchedMacros) {
+        newCode = newCode.replace(
+            createMacrosPattern(
+                [matchedMacro.slice(1)]
+            ),
+            macros.find(
+                macro => macro.name === matchedMacro.slice(1)
+            )?.code || ""
+        );
+    }
+
+    return newCode;
+};
+
+module.exports = {
+    hasMacros,
+    MacrosManager,
+    resolveMacros
+};

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -226,10 +226,12 @@ export declare class BaseClient extends Client {
     interactionManager: InteractionManager;
     cacheManager: CacheManager;
     variableManager: any;
+    macros: MacrosManager;
     prefix: string | string[];
     db: KeyValue | Transmitter;
     statuses: Group;
     constructor(options: ClientOptions);
+    macro(...macros: MacroOptions[]): void;
     status(...statuses: StatusOption[]): void;
     loadCommands(directory: string, debug?: boolean): void;
     variables(data: Record<string, unknown>, table?: string): void;
@@ -534,4 +536,42 @@ export interface Data<T extends Record<string, unknown> = Record<string, unknown
     interpreter: Interpreter;
     client: AoiClient;
     embed: EmbedBuilder;
+}
+
+/**
+ * An structure representing a macro.
+ */
+export interface MacroOptions {
+    /**
+     * The name of this macro (without #).
+     */
+    name: string;
+    /**
+     * The code of this macro.
+     */
+    code: string;
+}
+
+export declare class MacrosManager {
+    cache: Map<string, MacroOptions>;
+    /**
+     * Adds a macro to the manager.
+     */
+    add(macro: MacroOptions): this;
+    /**
+     * Adds many macros to the manager.
+     */
+    addMany(macros: MacroOptions[]): this;
+    /**
+     * Get a macro.
+     */
+    get(name: string | ((macro: MacroOptions) => boolean)): MacroOptions | null;
+    /**
+     * Return the list of cached macro names.
+     */
+    list(): string[];
+    /**
+     * Return an array of cached macros.
+     */
+    toArray(): MacroOptions[];
 }


### PR DESCRIPTION
## Description
This pull request introduces a new feature: **Macros**.
This is a concept I have seen in V7 currently in development that I seemed interesting and useful.
Let's Ayaka explain what is this for.
<img src="https://media.discordapp.net/attachments/773356408334581770/1305321158656397382/image.png?ex=67329a8f&is=6731490f&hm=2fc41f393f5c68626fa84a1b31b859fb9b675f784f276f2d27342826e10e680f&=&format=webp&quality=lossless" alt="drawing" width="500"/>
Since this is an adapted version for aoi.js v6, it does not provide support for JavaScript code in macro code.
I also added TypeScript definitions for this feature.

### Test
Tested code...
```js
client.macro({
    name: 'logmessage',
    code: '$log[hallo world c:]'
},{
    name: 'onlyDevelopers',
    code: '$onlyIf[$authorID==918231238912839;You are not a developer.]'
});

client.readyCommand({
    code: `
        $log[message $log[test_$randomString[10]] #logmessage]
        $log[test_$randomString[10]]#data$log[test_$randomString[10]]
        $log[test_$randomString[10]]
        #data$log[test_$randomString[10]]
        $log[test_$randomString[10]]
        #logmessage#logmessage#logmessage
        #logmessage$log[test_$randomString[10]]
        #logmessage
        $log[test_$randomString[10]]#logmessage
    `
});

client.command({
    name: "eval",
    code: `
        $eval[$message]
        #onlyDevelopers
    `
});
```

### Results
![logmessage macro](https://media.discordapp.net/attachments/773356408334581770/1305322634245832726/image.png?ex=67329bef&is=67314a6f&hm=faa14eca148bea66fe68bdf7f44e3bf117ee58b86019e1ff88d18f20c8eead93&=&format=webp&quality=lossless)
![onlydev macro](https://media.discordapp.net/attachments/1092490880436408410/1305320057005543577/image.png?ex=67329989&is=67314809&hm=918c7c837fee3cd69e4272fdef21e711f3d2df2edf1e3a10818561e6df419e10&=&format=webp&quality=lossless)

## Type of change
- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

---

- [x] My code follows the style guidelines of this project
- [x] Any dependent changes have been merged and published in downstream modules
