### PR TITLE
Fix macro resolution

### DIFF
--- a/src/classes/Commands.js
+++ b/src/classes/Commands.js
@@ -14,7 +14,7 @@ class Command {
 
         this.__client__ = client;
         
-        if (hasMacros(client.macros.list(), data.code)) {
+        if (client.macros.list().length > 0 && hasMacros(client.macros.list(), data.code)) {
             data.code = resolveMacros(client.macros.toArray(), data.code);
         }
 

--- a/src/classes/Macros.js
+++ b/src/classes/Macros.js
@@ -65,7 +65,7 @@ class MacrosManager {
  * @returns {RegExp}
  */
 function createMacrosPattern(names) {
-    return new RegExp(`#(${names.join("|")})`, "g");
+    return new RegExp(`(${names.map(name => `#${name}`).join("|")})`, "g");
 };
 
 /**
@@ -85,17 +85,20 @@ function hasMacros(names, code) {
  * @returns {string}
  */
 function resolveMacros(macros, code) {
+    if (macros.length === 0) return code;
+
     const matchedMacros = [...new Set(code.match(createMacrosPattern(macros.map(m => m.name))) ?? [])];
     let newCode = code;
 
     for (const matchedMacro of matchedMacros) {
+        const gotMacro = macros.find(macro => macro.name === matchedMacro.slice(1))
+        if (!gotMacro) continue;
+
         newCode = newCode.replace(
             createMacrosPattern(
                 [matchedMacro.slice(1)]
             ),
-            macros.find(
-                macro => macro.name === matchedMacro.slice(1)
-            )?.code || ""
+            gotMacro.code
         );
     }
 


### PR DESCRIPTION
## Description
This pull request fixes an accidentally introduced bug in macros feature.
It basically were replacing every "#word", "# word" to an empty string, that wasn't intended to happen.
Now it replaces the possible macros in the code only if theres ones cached and checks if the current macro exists, if they don't skips to the next match.

## Type of change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
- [x] My code follows the style guidelines of this project
- [x] Any dependent changes have been merged and published in downstream modules
