### PR TITLE
add components checking

### DIFF
--- a/src/classes/AoiError.js
+++ b/src/classes/AoiError.js
@@ -88,7 +88,7 @@ class AoiError {
 
         let msg;
         if (extraOptions.interaction) {
-            if (options.content === "" && options.embeds?.length === 0 && options.files?.length === 0) return;
+            if (options.content === "" && options.embeds?.length === 0 && options.files?.length === 0 && options.components?.length === 0) return;
             if (extraOptions?.defer) {
                 await d.data.interaction.deferReply({
                     ephemeral: extraOptions.ephemeral ?? options.ephemeral
@@ -106,13 +106,13 @@ class AoiError {
             }
         } else {
             if (channel instanceof BaseInteraction) {
-                if (options.content === "" && options.embeds?.length === 0 && options.files?.length === 0) return;
+                if (options.content === "" && options.embeds?.length === 0 && options.files?.length === 0 && options.components?.length === 0) return;
                 msg = await channel.reply(options).catch((e) => {
                     AoiError.consoleError("CreateMessageError", e);
                     return undefined;
                 });
             } else {
-                if (options.content === " " && (options.embeds?.length ?? 0) === 0 && (options.files?.length ?? 0) === 0 && (options.stickers?.length ?? 0) === 0) return;
+                if (options.content === " " && (options.embeds?.length ?? 0) === 0 && (options.files?.length ?? 0) === 0 && (options.stickers?.length ?? 0) === 0 && (options.components?.length ?? 0) === 0) return;
 
                 if (extraOptions.reply?.message) {
                     if (extraOptions.reply?.mention) options.allowedMentions.repliedUser = true;

--- a/src/core/interpreter.js
+++ b/src/core/interpreter.js
@@ -473,7 +473,7 @@ const Interpreter = async (client, message, args, command, _db, returnCode = fal
             returnData.data = data;
         }
 
-        if ((code.length || embeds?.length || attachments?.length) && !errorOccurred && !error) {
+        if ((code.length || embeds?.length || attachments?.length || components?.length) && !errorOccurred && !error) {
             try {
                 const send = {
                     embeds: embeds,


### PR DESCRIPTION
## Description

implemented changes to ensure that messages containing only components (without any content, attachments or embeds) can still be sent.

this changes also applies to functions such as `$sendMessage`, `$channelSendMessage`, `$sendDM`, and other similar functions responsible for sending messages that support components parser

## Type of change

Please check options that describe your Pull Request:

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

- [x] My code follows the style guidelines of this project
- [ ] Any dependent changes have been merged and published in downstream modules
