### PR TITLE
fix guild vanity functions

### DIFF
--- a/src/functions/guildVanityURL.js
+++ b/src/functions/guildVanityURL.js
@@ -3,12 +3,12 @@
  */
 module.exports = async d => {
     const data = d.util.aoiFunc(d);
-
-    const [guildID = d.guild?.id] = data.inside.splits;
+    const [guildID = d.guild?.id, fetchFirst = 'false'] = data.inside.splits;
 
     const guild = await d.util.getGuild(d, guildID);
     if (!guild) return d.aoiError.fnError(d, 'guild', {inside: data.inside});
 
+    if (fetchFirst == 'true') await guild.fetchVanityData().catch(Boolean);
     data.result = guild.vanityURLCode ? `discord.gg/${guild.vanityURLCode}` : 'undefined';
 
     return {

--- a/src/functions/guildVanityUses.js
+++ b/src/functions/guildVanityUses.js
@@ -3,12 +3,12 @@
  */
 module.exports = async d => {
     const data = d.util.aoiFunc(d);
-
-    const [guildID = d.guild?.id] = data.inside.splits;
+    const [guildID = d.guild?.id, fetchFirst = 'false'] = data.inside.splits;
 
     const guild = await d.util.getGuild(d, guildID);
     if (!guild) return d.aoiError.fnError(d, 'guild', {inside: data.inside});
 
+    if (fetchFirst == 'true') await guild.fetchVanityData().catch(Boolean);
     data.result = guild.vanityURLUses;
 
     return {


### PR DESCRIPTION
## Description

Added a new `fetchFirst?` parameter to `$guildVanityUses` and `$guildVanityURL` to prioritize fetching the vanity data first, preventing empty returns. This change requires an update to the documentation.

Reference Report: **[$guildVanityUses return nothing](https://discord.com/channels/773352845738115102/1338553730961772544/1338553832954789888)**

## Type of change

Please check options that describe your Pull Request:

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

---

- [x] My code follows the style guidelines of this project
- [ ] Any dependent changes have been merged and published in downstream modules
