### PR TITLE
Fixed getGuild() Util for sharding

### DIFF
--- a/src/classes/Util.js
+++ b/src/classes/Util.js
@@ -90,13 +90,8 @@ class Util {
 
     static async getGuild(d, id) {
         if (d.guild?.id === id && d.guild?.id) return d.guild;
-        else {
-            if (!d.client.shard) return d.client.guilds.cache.get(id);
-            else {
-                const arr = await d.client.shard.broadcastEval((client) => client.guilds.cache.get(id));
-                return arr.find((x) => x);
-            }
-        }
+    
+        return d.client.guilds.cache.get(id) || await d.client.guilds.fetch(id, { force: true });
     }
 
     static get channelTypes() {


### PR DESCRIPTION
## Description

Fixes issue when guild data is fetched from another shard, Previously, broadcastEval was returning plain objects, causing the loss of mapping properties... 

Fixes # (issue number / __remove this line__ if no issue is to be referenced)

## Type of change

Please check options that describe your Pull Request:

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

- [x] My code follows the style guidelines of this project
- [x] Any dependent changes have been merged and published in downstream modules
