### PR TITLE
fix $createApplicationCommand for message & user type

### DIFF
--- a/src/functions/createApplicationCommand.js
+++ b/src/functions/createApplicationCommand.js
@@ -26,7 +26,7 @@ module.exports = async (d) => {
         data: {
             name: name,
             type: SlashTypes[type] || type,
-            description: description?.addBrackets(),
+            ...(type === "slash" ? { description: description?.addBrackets() } : {}),
             defaultMemberPermissions: appPermissions.includes(undefined) ? null : appPermissions,
             contexts: appContext,
             integrationTypes: appIntegrationType,


### PR DESCRIPTION
## Description

fixed an issue where description field was incorrectly added for message & user types, causing "DiscordAPIError[50035]: Invalid Form Body
description[APPLICATION_COMMAND_CONTEXT_MENU_DESCRIPTION_INVALID]: Context menu commands cannot have description"

Fixes # (issue number / __remove this line__ if no issue is to be referenced)

## Type of change

Please check options that describe your Pull Request:

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

- [x] My code follows the style guidelines of this project
- [x] Any dependent changes have been merged and published in downstream modules
