### PR TITLE
fix(parser): button label with colon doesn't work

### DIFF
--- a/src/events/parsers.js
+++ b/src/events/parsers.js
@@ -176,8 +176,8 @@ const ComponentParser = async (message, d) => {
             for (let button of inside) {
                 button = button?.split("}")[0];
                 button = button
-                ?.split(/:(?![/][/])/)
-                .map((x) => x.trim().addBrackets());
+                    ?.split(/:(?![/][/])/)
+                    .map((x) => x.trim().addBrackets());
 
                 const label = button.shift();
                 let style = isNaN(button[0]) ? button.shift() : Number(button.shift());

--- a/src/events/parsers.js
+++ b/src/events/parsers.js
@@ -176,9 +176,8 @@ const ComponentParser = async (message, d) => {
             for (let button of inside) {
                 button = button?.split("}")[0];
                 button = button
-                    ?.addBrackets()
-                    .split(/:(?![/][/])/)
-                    .map((x) => x.trim());
+                ?.split(/:(?![/][/])/)
+                .map((x) => x.trim().addBrackets());
 
                 const label = button.shift();
                 let style = isNaN(button[0]) ? button.shift() : Number(button.shift());


### PR DESCRIPTION
## Description

this PR fix a bug where button label with colon doesn't work even with `#COLON#`

[Issue from discord](https://discord.com/channels/773352845738115102/1334218009002381323)

## Type of change

Please check options that describe your Pull Request:

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

- [x] My code follows the style guidelines of this project
- [ ] Any dependent changes have been merged and published in downstream modules
