### PR TITLE
New function, new parameter for $clientPrefixes & bug fix

### DIFF
--- a/src/core/functions.js
+++ b/src/core/functions.js
@@ -122,7 +122,8 @@ module.exports = {
             footericon: embed.footer?.iconURL,
             description: embed.description,
             title: embed.title,
-            url: embed?.url
+            url: embed?.url,
+            timestamp: embed.timestamp? new Date(embed.timestamp).toISOString() : null
         };
 
         embed.fields.forEach((x, y) => (data[`field${y + 1}`] = x));

--- a/src/functions/allApplicationCommands.js
+++ b/src/functions/allApplicationCommands.js
@@ -1,0 +1,19 @@
+/**  
+ * @param {import("..").Data} d  
+ */  
+module.exports = async (d) => {  
+    const data = d.util.aoiFunc(d);  
+  
+    if (data.err) return d.error(data.err);  
+  
+    let [separator = ','] = data.inside.splits;  
+    try {  
+        const slashCommands = await client.application.commands.fetch();  
+        const formattedSlashCommands = slashCommands.map(command => command.name).join(` ${separator} `)  
+   } catch (e) {  
+         return d.aoiError.fnError(d, 'custom', {}, `Failed to fetch all slash commands with the reason: ${e}`);  
+    }  
+    return {  
+        code: d.util.setCode(data),  
+    };  
+};

--- a/src/functions/clientPrefixes.js
+++ b/src/functions/clientPrefixes.js
@@ -5,7 +5,7 @@ module.exports = async (d) => {
     const data = d.util.aoiFunc(d);
     if (data.err) return d.error(data.err);
     
-    let [separator = ',', includeSpaces = true] = data.inside.splits;
+    let [separator = ','] = data.inside.splits;
     
     if (Array.isArray(d.client.prefix)) {
         data.result = d.client.prefix.join(" " + separator + " ");

--- a/src/functions/clientPrefixes.js
+++ b/src/functions/clientPrefixes.js
@@ -8,11 +8,7 @@ module.exports = async (d) => {
     let [separator = ',', includeSpaces = true] = data.inside.splits;
     
     if (Array.isArray(d.client.prefix)) {
-        if (includeSpaces == false) {
-            data.result = d.client.prefix.join(separator);
-        } else if (includeSpaces == true) {
-            data.result = d.client.prefix.join(" " + separator + " ");
-        }
+        data.result = d.client.prefix.join(" " + separator + " ");
     } else {
         data.result = d.client.prefix;
     }

--- a/src/functions/clientPrefixes.js
+++ b/src/functions/clientPrefixes.js
@@ -3,9 +3,12 @@
  */
 module.exports = async (d) => {
     const data = d.util.aoiFunc(d);
-
+    if (data.err) return d.error(data.err);
+    
+    let [separator = ','] = data.inside.splits;
+    
     if (Array.isArray(d.client.prefix)) {
-        data.result = d.client.prefix.join(" , ");
+        data.result = d.client.prefix.join(" " + separator + " ");
     } else {
         data.result = d.client.prefix;
     }

--- a/src/functions/clientPrefixes.js
+++ b/src/functions/clientPrefixes.js
@@ -5,10 +5,14 @@ module.exports = async (d) => {
     const data = d.util.aoiFunc(d);
     if (data.err) return d.error(data.err);
     
-    let [separator = ','] = data.inside.splits;
+    let [separator = ',', includeSpaces = true] = data.inside.splits;
     
     if (Array.isArray(d.client.prefix)) {
-        data.result = d.client.prefix.join(" " + separator + " ");
+        if (includeSpaces == false) {
+            data.result = d.client.prefix.join(separator);
+        } else if (includeSpaces == true) {
+            data.result = d.client.prefix.join(" " + separator + " ");
+        }
     } else {
         data.result = d.client.prefix;
     }

--- a/src/functions/clientPrefixes.js
+++ b/src/functions/clientPrefixes.js
@@ -8,7 +8,7 @@ module.exports = async (d) => {
     let [separator = ','] = data.inside.splits;
     
     if (Array.isArray(d.client.prefix)) {
-        data.result = d.client.prefix.join(" " + separator + " ");
+        data.result = d.client.prefix.join(` ${separator} `);
     } else {
         data.result = d.client.prefix;
     }


### PR DESCRIPTION
## Description

Added seperator and includeSpaces arguments to $clientPrefixes, so you can get different seperators instead of "," 
Added $allApplicationCommands which returns all slash commands
(idk if they work first time doing this)

## Type of change

- [ ] Bug fix (non-breaking change)
- [ ✓] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [✓ ] This change requires a documentation update

---

- [✓ ] My code follows the style guidelines of this project
- [ ] Any dependent changes have been merged and published in downstream modules
