### PR TITLE
feat: add optional encoding to $attachment

### DIFF
--- a/src/functions/attachment.js
+++ b/src/functions/attachment.js
@@ -8,12 +8,18 @@ module.exports = async (d) => {
     if (data.err) return d.error(data.err);
 
     let [attachment, name, type = "url", encoding] = data.inside.splits;
-    const result = new AttachmentBuilder(
-        type === "buffer"
-            ? Buffer.from(attachment.addBrackets(), encoding)
-            : attachment.addBrackets(),
-        {name: name.addBrackets()},
-    );
+
+    if(type === "buffer") {
+        try {
+            attachment = Buffer.from(attachment.addBrackets(), encoding)
+        } catch (e) {
+            return d.aoiError.fnError(d, 'custom', {}, e.message);
+        }
+    } else {
+        attachment = attachment.addBrackets();
+    }
+
+    const result = new AttachmentBuilder(attachment, { name: name.addBrackets() });
     d.files.push(result);
     
     return {

--- a/src/functions/attachment.js
+++ b/src/functions/attachment.js
@@ -7,10 +7,10 @@ module.exports = async (d) => {
     const data = d.util.aoiFunc(d);
     if (data.err) return d.error(data.err);
 
-    let [attachment, name, type = "url"] = data.inside.splits;
+    let [attachment, name, type = "url", encoding] = data.inside.splits;
     const result = new AttachmentBuilder(
         type === "buffer"
-            ? Buffer.from(attachment.addBrackets())
+            ? Buffer.from(attachment.addBrackets(), encoding)
             : attachment.addBrackets(),
         {name: name.addBrackets()},
     );

--- a/src/functions/attachment.js
+++ b/src/functions/attachment.js
@@ -1,4 +1,4 @@
-const {AttachmentBuilder} = require("discord.js");
+const { AttachmentBuilder } = require("discord.js");
 
 /**
  * @param {import("..").Data} d
@@ -9,11 +9,11 @@ module.exports = async (d) => {
 
     let [attachment, name, type = "url", encoding] = data.inside.splits;
 
-    if(type === "buffer") {
+    if (type === "buffer") {
         try {
-            attachment = Buffer.from(attachment.addBrackets(), encoding)
+            attachment = Buffer.from(attachment.addBrackets(), encoding);
         } catch (e) {
-            return d.aoiError.fnError(d, 'custom', {}, e.message);
+            return d.aoiError.fnError(d, "custom", {}, e.message);
         }
     } else {
         attachment = attachment.addBrackets();
@@ -21,9 +21,9 @@ module.exports = async (d) => {
 
     const result = new AttachmentBuilder(attachment, { name: name.addBrackets() });
     d.files.push(result);
-    
+
     return {
         code: d.util.setCode(data),
-        files: d.files,
+        files: d.files
     };
 };


### PR DESCRIPTION
## Description

Add optional encoding to $attachment if the type is `buffer` because by default node.js Buffer.from encoding is utf8

[Based on this suggestion](https://discord.com/channels/773352845738115102/1199204494781722674/threads/1274400697340657939)

## Type of change

Please check options that describe your Pull Request:

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

---

- [x] My code follows the style guidelines of this project
- [ ] Any dependent changes have been merged and published in downstream modules
