### PR TITLE
fix: separator not working in $numberSeparator

### DIFF
--- a/src/functions/numberSeparator.js
+++ b/src/functions/numberSeparator.js
@@ -11,7 +11,7 @@ module.exports = d => {
 
     const splits = number.split('.');
 
-    data.result = Number(splits[0]).toLocaleString().replaceAll(",", sep.addBrackets())
+    data.result = Number(splits[0]).toLocaleString("en-US").replaceAll(",", sep.addBrackets())
     if (splits[1]) {
         data.result = data.result + '.' + splits[1];
     }


### PR DESCRIPTION
## Description

Fix separator not working on some language setting

## Type of change

Please check options that describe your Pull Request:

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

- [x] My code follows the style guidelines of this project
- [ ] Any dependent changes have been merged and published in downstream modules
