### PR TITLE
Fix guildExists

### DIFF
--- a/src/functions/guildExists.js
+++ b/src/functions/guildExists.js
@@ -7,7 +7,9 @@ module.exports = async d => {
 
     const guildID = data.inside.inside;
 
-    data.result = !!(await d.util.getGuild(d, guildID));
+    const guild = await d.util.getGuild(d, guildID);
+    
+    data.result = guild ? true : false;
 
     return {
         code: d.util.setCode(data)

--- a/src/functions/guildExists.js
+++ b/src/functions/guildExists.js
@@ -7,9 +7,11 @@ module.exports = async d => {
 
     const guildID = data.inside.inside;
 
-    const guild = await d.util.getGuild(d, guildID);
+    const guild = !!(await d.util.getGuild(d, guildID).catch(() => {
+        return false;
+    }));  
     
-    data.result = guild ? true : false;
+    data.result = guild;
 
     return {
         code: d.util.setCode(data)


### PR DESCRIPTION
Fix to return false when guild not found.

## Description

There was an issue with `$guildExists` returning undefined when guild doesn't exist as said in [this message](https://discord.com/channels/773352845738115102/1035374939420754001/1376169501845884990) and the fix was also recommended by `@lawerth` on [this message](https://discord.com/channels/773352845738115102/1035374939420754001/1376177881113296936). So, credits to him/her. I'm just doing the PR since he/she said he/she doesn't know. 

Also, `@fafa` helped to change it again.

## Type of change

Please check options that describe your Pull Request:

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

- [x] My code follows the style guidelines of this project
- [ ] Any dependent changes have been merged and published in downstream modules
