### PR TITLE
fix: $setTimeout

### DIFF
--- a/src/events/Custom/timeout.js
+++ b/src/events/Custom/timeout.js
@@ -1,5 +1,6 @@
+const MAX_SAFE_TIMEOUT_DURATION = 0x7fffffff;
+
 module.exports = async (d, duration, timeoutData, onReady) => {
-    const MAX_SAFE_TIMEOUT_DURATION = 0x7fffffff;
     let cmds = d.client.cmd?.timeout.V();
 
     if (onReady) {
@@ -30,7 +31,7 @@ module.exports = async (d, duration, timeoutData, onReady) => {
 
             await d.client.db.delete("__aoijs_vars__", `setTimeout_${timeoutData.__id__}`);
             clearInterval(interval);
-        }, 3600000);
+        }, 3_600_000);
 
         await d.client.db.set("__aoijs_vars__", "setTimeout", timeoutData.__id__, {
             ...timeoutData,
@@ -60,7 +61,6 @@ module.exports = async (d, duration, timeoutData, onReady) => {
 };
 
 async function handleResidueData(d) {
-    const MAX_SAFE_TIMEOUT_DURATION = 0x7fffffff;
     const td = await d.client.db.all("__aoijs_vars__", (data) => data.key.startsWith("setTimeout_"));
     let cmds = d.client.cmd?.timeout.V();
 
@@ -87,7 +87,7 @@ async function handleResidueData(d) {
 
                     await d.client.db.delete("__aoijs_vars__", `setTimeout_${timeoutData.__id__}`);
                     clearInterval(interval);
-                }, 3600000);
+                }, 3_600_000);
 
                 await d.client.db.set("__aoijs_vars__", "setTimeout", timeoutData.__id__, {
                     ...timeoutData,

--- a/src/events/Custom/timeout.js
+++ b/src/events/Custom/timeout.js
@@ -20,7 +20,7 @@ module.exports = async (d, duration, timeoutData, onReady) => {
             cmds = cmds.filter((x) => x.name === timeoutData.__timeoutName__);
             for (const cmd of cmds) {
                 if (cmd.channel) {
-                    const channel = await d.util.getChannel(d, cmd.channel);
+                    const channel = await getChannel(d, cmd.channel);
                     if (!channel) return d.aoiError.fnError(d, "custom", {}, `Invalid channel ID in timeout command: ${cmd.channel}`);
                     await d.interpreter(d.client, { channel }, [], cmd, d.client.db, false, undefined, { timeoutData });
                 } else {
@@ -41,7 +41,7 @@ module.exports = async (d, duration, timeoutData, onReady) => {
             cmds = cmds.filter((x) => x.name === timeoutData.__timeoutName__);
             for (const cmd of cmds) {
                 if (cmd.channel) {
-                    const channel = await d.util.getChannel(d, cmd.channel);
+                    const channel = await getChannel(d, cmd.channel);
                     if (!channel) return d.aoiError.fnError(d, "custom", {}, `Invalid channel ID in timeout command: ${cmd.channel}`);
                     await d.interpreter(d.client, { channel }, [], cmd, d.client.db, false, undefined, { timeoutData });
                 } else {
@@ -77,7 +77,7 @@ async function handleResidueData(d) {
                     cmds = cmds.filter((x) => x.name === timeoutData.__timeoutName__);
                     for (const cmd of cmds) {
                         if (cmd.channel) {
-                            const channel = await d.util.getChannel(d, cmd.channel);
+                            const channel = await getChannel(d, cmd.channel);
                             if (!channel) return d.aoiError.fnError(d, "custom", {}, `Invalid channel ID in timeout command: ${cmd.channel}`);
                             await d.interpreter(d.client, { channel }, [], cmd, d.client.db, false, undefined, { timeoutData });
                         } else {
@@ -98,7 +98,7 @@ async function handleResidueData(d) {
                     cmds = cmds.filter((x) => x.name === timeoutData.__timeoutName__);
                     for (const cmd of cmds) {
                         if (cmd.channel) {
-                            const channel = await d.util.getChannel(d, cmd.channel);
+                            const channel = await getChannel(d, cmd.channel);
                             if (!channel) return d.aoiError.fnError(d, "custom", {}, `Invalid channel ID in timeout command: ${cmd.channel}`);
                             await d.interpreter(d.client, { channel }, [], cmd, d.client.db, false, undefined, { timeoutData });
                         } else {
@@ -118,7 +118,7 @@ async function handleResidueData(d) {
             cmds = cmds.filter((x) => x.name === timeoutData.__timeoutName__);
             for (const cmd of cmds) {
                 if (cmd.channel) {
-                    const channel = d.client.channels.cache.get(cmd.channel) || (await d.client.channels.fetch(cmd.channel).catch(() => null));
+                    const channel = await getChannel(d, cmd.channel);
                     if (!channel) return d.aoiError.fnError(d, "custom", {}, `Invalid channel ID in timeout command: ${cmd.channel}`);
                     await d.interpreter(d.client, { channel }, [], cmd, d.client.db, false, undefined, { timeoutData });
                 } else {
@@ -129,4 +129,9 @@ async function handleResidueData(d) {
             await d.client.db.delete("__aoijs_vars__", `setTimeout_${timeoutData.__id__}`);
         }
     }
+}
+
+async function getChannel(d, channel) {
+    if (d.util) return await d.util.getChannel(d, channel, true);
+    return d.client.channels.cache.get(cmd.channel) || (await d.client.channels.fetch(cmd.channel).catch(() => null));
 }

--- a/src/events/Custom/timeout.js
+++ b/src/events/Custom/timeout.js
@@ -1,6 +1,6 @@
 module.exports = async (d, duration, timeoutData, onReady) => {
+    const MAX_SAFE_TIMEOUT_DURATION = 0x7fffffff;
     let cmds = d.client.cmd?.timeout.V();
-    const MAX_SAFE_TIMEOUT_DURATION = 0x7FFFFFFF;
 
     if (onReady) {
         if (d.client?.db?.db?.readyAt) {
@@ -10,77 +10,89 @@ module.exports = async (d, duration, timeoutData, onReady) => {
                 await handleResidueData(d);
             });
         }
+        return;
+    }
+
+    if (duration > MAX_SAFE_TIMEOUT_DURATION) {
+        const interval = setInterval(async () => {
+            if (timeoutData.__duration__ > Date.now()) return;
+
+            cmds = cmds.filter((x) => x.name === timeoutData.__timeoutName__);
+            for (const cmd of cmds) {
+                if (cmd.channel) {
+                    const channel = await d.util.getChannel(d, cmd.channel);
+                    if (!channel) return d.aoiError.fnError(d, "custom", {}, `Invalid channel ID in timeout command: ${cmd.channel}`);
+                    await d.interpreter(d.client, { channel }, [], cmd, d.client.db, false, undefined, { timeoutData });
+                } else {
+                    await d.interpreter(d.client, {}, [], cmd, d.client.db, false, undefined, { timeoutData });
+                }
+            }
+
+            await d.client.db.delete("__aoijs_vars__", `setTimeout_${timeoutData.__id__}`);
+            clearInterval(interval);
+        }, 3600000);
+
+        await d.client.db.set("__aoijs_vars__", "setTimeout", timeoutData.__id__, {
+            ...timeoutData,
+            __timerID__: interval[Symbol.toPrimitive]()
+        });
     } else {
-        if (duration > MAX_SAFE_TIMEOUT_DURATION) {
-            const interval = setInterval(
-                async () => {
-                    if (!(timeoutData.__duration__ <= Date.now())) return;
+        const timeout = setTimeout(async () => {
+            cmds = cmds.filter((x) => x.name === timeoutData.__timeoutName__);
+            for (const cmd of cmds) {
+                if (cmd.channel) {
+                    const channel = await d.util.getChannel(d, cmd.channel);
+                    if (!channel) return d.aoiError.fnError(d, "custom", {}, `Invalid channel ID in timeout command: ${cmd.channel}`);
+                    await d.interpreter(d.client, { channel }, [], cmd, d.client.db, false, undefined, { timeoutData });
+                } else {
+                    await d.interpreter(d.client, {}, [], cmd, d.client.db, false, undefined, { timeoutData });
+                }
+            }
+
+            await d.client.db.delete("__aoijs_vars__", `setTimeout_${timeoutData.__id__}`);
+        }, duration);
+
+        await d.client.db.set("__aoijs_vars__", "setTimeout", timeoutData.__id__, {
+            ...timeoutData,
+            __timerID__: timeout[Symbol.toPrimitive]()
+        });
+    }
+};
+
+async function handleResidueData(d) {
+    const MAX_SAFE_TIMEOUT_DURATION = 0x7fffffff;
+    const td = await d.client.db.all("__aoijs_vars__", (data) => data.key.startsWith("setTimeout_"));
+    let cmds = d.client.cmd?.timeout.V();
+
+    for (const data of td) {
+        const timeoutData = data.value;
+
+        if (Date.now() <= timeoutData.__duration__) {
+            const remaining = timeoutData.__duration__ - Date.now();
+
+            if (remaining > MAX_SAFE_TIMEOUT_DURATION) {
+                const interval = setInterval(async () => {
+                    if (timeoutData.__duration__ > Date.now()) return;
+
                     cmds = cmds.filter((x) => x.name === timeoutData.__timeoutName__);
                     for (const cmd of cmds) {
                         if (cmd.channel) {
                             const channel = await d.util.getChannel(d, cmd.channel);
                             if (!channel) return d.aoiError.fnError(d, "custom", {}, `Invalid channel ID in timeout command: ${cmd.channel}`);
-
                             await d.interpreter(d.client, { channel }, [], cmd, d.client.db, false, undefined, { timeoutData });
                         } else {
                             await d.interpreter(d.client, {}, [], cmd, d.client.db, false, undefined, { timeoutData });
                         }
                     }
+
                     await d.client.db.delete("__aoijs_vars__", `setTimeout_${timeoutData.__id__}`);
                     clearInterval(interval);
-                },
-                60 * 60 * 1000
-            );
-            await d.client.db.set("__aoijs_vars__", "setTimeout", timeoutData.__id__, { ...timeoutData, __timerID__: interval[Symbol.toPrimitive]() });
-        } else {
-            const timeout = setTimeout(async () => {
-                cmds = cmds.filter((x) => x.name === timeoutData.__timeoutName__);
-                for (const cmd of cmds) {
-                    if (cmd.channel) {
-                        const channel = await d.util.getChannel(d, cmd.channel);
-                        if (!channel) return d.aoiError.fnError(d, "custom", {}, `Invalid channel ID in timeout command: ${cmd.channel}`);
+                }, 3600000);
 
-                        await d.interpreter(d.client, { channel }, [], cmd, d.client.db, false, undefined, { timeoutData });
-                    } else {
-                        await d.interpreter(d.client, {}, [], cmd, d.client.db, false, undefined, { timeoutData });
-                    }
-                }
-                await d.client.db.delete("__aoijs_vars__", `setTimeout_${timeoutData.__id__}`);
-            }, duration);
-            await d.client.db.set("__aoijs_vars__", "setTimeout", timeoutData.__id__, { ...timeoutData, __timerID__: timeout[Symbol.toPrimitive]() });
-        }
-    }
-};
-
-async function handleResidueData(d) {
-    const td = await d.client.db.all("__aoijs_vars__", (data) => data.key.startsWith("setTimeout_"));
-    let cmds = d.client.cmd?.timeout.V();
-    const MAX_SAFE_TIMEOUT_DURATION = 0x7FFFFFFF;
-
-    for (const data of td) {
-        const timeoutData = data.value;
-        if (Date.now() <= timeoutData.__duration__) {
-            if ((timeoutData.__duration__ - Date.now()) > MAX_SAFE_TIMEOUT_DURATION) {
-                const interval = setInterval(
-                    async () => {
-                        if (!(timeoutData.__duration__ <= Date.now())) return;
-                        cmds = cmds.filter((x) => x.name === timeoutData.__timeoutName__);
-                        for (const cmd of cmds) {
-                            if (cmd.channel) {
-                                const channel = await d.util.getChannel(d, cmd.channel);
-                                if (!channel) return d.aoiError.fnError(d, "custom", {}, `Invalid channel ID in timeout command: ${cmd.channel}`);
-
-                                await d.interpreter(d.client, { channel }, [], cmd, d.client.db, false, undefined, { timeoutData });
-                            } else {
-                                await d.interpreter(d.client, {}, [], cmd, d.client.db, false, undefined, { timeoutData });
-                            }
-                        }
-                        await d.client.db.delete("__aoijs_vars__", `setTimeout_${timeoutData.__id__}`);
-                        clearInterval(interval);
-                    },
-                    60 * 60 * 1000
-                );
-                await d.client.db.set("__aoijs_vars__", "setTimeout", timeoutData.__id__, { ...timeoutData, __timerID__: interval[Symbol.toPrimitive]() });
+                await d.client.db.set("__aoijs_vars__", "setTimeout", timeoutData.__id__, {
+                    ...timeoutData,
+                    __timerID__: interval[Symbol.toPrimitive]()
+                });
             } else {
                 const timeout = setTimeout(async () => {
                     cmds = cmds.filter((x) => x.name === timeoutData.__timeoutName__);
@@ -88,27 +100,32 @@ async function handleResidueData(d) {
                         if (cmd.channel) {
                             const channel = await d.util.getChannel(d, cmd.channel);
                             if (!channel) return d.aoiError.fnError(d, "custom", {}, `Invalid channel ID in timeout command: ${cmd.channel}`);
-
                             await d.interpreter(d.client, { channel }, [], cmd, d.client.db, false, undefined, { timeoutData });
                         } else {
                             await d.interpreter(d.client, {}, [], cmd, d.client.db, false, undefined, { timeoutData });
                         }
                     }
+
                     await d.client.db.delete("__aoijs_vars__", `setTimeout_${timeoutData.__id__}`);
-                }, timeoutData.__duration__ - Date.now());
-                await d.client.db.set("__aoijs_vars__", "setTimeout", timeoutData.__id__, { ...timeoutData, __timerID__: timeout[Symbol.toPrimitive]() });
+                }, remaining);
+
+                await d.client.db.set("__aoijs_vars__", "setTimeout", timeoutData.__id__, {
+                    ...timeoutData,
+                    __timerID__: timeout[Symbol.toPrimitive]()
+                });
             }
         } else {
             cmds = cmds.filter((x) => x.name === timeoutData.__timeoutName__);
             for (const cmd of cmds) {
                 if (cmd.channel) {
-                    const channel = d.client.channels.cache.get(cmd.channel);
+                    const channel = d.client.channels.cache.get(cmd.channel) || (await d.client.channels.fetch(cmd.channel).catch(() => null));
                     if (!channel) return d.aoiError.fnError(d, "custom", {}, `Invalid channel ID in timeout command: ${cmd.channel}`);
                     await d.interpreter(d.client, { channel }, [], cmd, d.client.db, false, undefined, { timeoutData });
                 } else {
                     await d.interpreter(d.client, {}, [], cmd, d.client.db, false, undefined, { timeoutData });
                 }
             }
+
             await d.client.db.delete("__aoijs_vars__", `setTimeout_${timeoutData.__id__}`);
         }
     }


### PR DESCRIPTION
## Description

This change fixes a bug in $setTimeout that caused messages to not be sent when the server restarted. This was caused by all channels not being fully cached by the client.

Also rewrote some lines of code to make it more readable while editing.

## Type of change

Please check options that describe your Pull Request:

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

- [x] My code follows the style guidelines of this project
- [ ] Any dependent changes have been merged and published in downstream modules
