### PR TITLE
Update createApplicationCommand.js

### DIFF
--- a/src/functions/misc/createApplicationCommand.js
+++ b/src/functions/misc/createApplicationCommand.js
@@ -1,45 +1,52 @@
 const { SlashTypes, ContextTypes, IntegrationTypes } = require("../../utils/InteractionConstants.js");
 const { Permissions } = require("../../utils/Constants.js");
 
-/**
- * @param {import("..").Data} d
- */
 module.exports = async (d) => {
-    const data = d.util.aoiFunc(d);
-    if (data.err) return d.error(data.err);
+  const data = d.util.aoiFunc(d);
+  if (data.err) return d.error(data.err);
 
-    const [guildID, name, description, defaultMemberPermissions = "", integrationType = "", contexts = "all", type = "slash", options] = data.inside.splits;
+  const [guildID, name, description, defaultMemberPermissions = "", integrationType = "", contexts = "all", type = "slash", options] = data.inside.splits;
 
-    const guild = guildID === "global" ? undefined : await d.util.getGuild(d, guildID);
-    if (!guild && guildID !== "global") return d.aoiError.fnError(d, "guild", { inside: data.inside });
+  const guild = guildID === "global" ? undefined : await d.util.getGuild(d, guildID);
+  if (!guild && guildID !== "global") return d.aoiError.fnError(d, "guild", { inside: data.inside });
 
-    const appContext = contexts === "all" || contexts.trim() === "" ? [ContextTypes.botdm, ContextTypes.dm, ContextTypes.guild] : contexts.split(",").map((x) => ContextTypes[x]);
+  const appContext = contexts === "all" || contexts.trim() === "" ? [ContextTypes.botdm, ContextTypes.dm, ContextTypes.guild] : contexts.split(",").map((x) => ContextTypes[x]);
+  if (appContext.includes(undefined)) return d.aoiError.fnError(d, "custom", { inside: data.inside }, "Invalid Context, valid options: " + Object.keys(ContextTypes).join(","));
 
-    const appIntegrationType =
-        integrationType === "all" || integrationType.trim() === "" ? [IntegrationTypes.guild, IntegrationTypes.user] : integrationType.split(",").map((x) => IntegrationTypes[x]);
+  const appIntegrationType =
+    integrationType === "all" || integrationType.trim() === "" ? [IntegrationTypes.guild, IntegrationTypes.user] : integrationType.split(",").map((x) => IntegrationTypes[x]);
 
-    if (appContext.includes(undefined)) return d.aoiError.fnError(d, "custom", { inside: data.inside }, "Invalid Context, valid options: " + Object.keys(ContextTypes).join(","));
+  const appPermissions = (defaultMemberPermissions.toLowerCase()).split(",").map((x) => Permissions[x]);
 
-    const appPermissions = (defaultMemberPermissions.toLowerCase()).split(",").map((x) => Permissions[x]);
+  let parsedOptions;
+  try {
+    parsedOptions = options ? JSON.parse(options) : {};
+  } catch (err) {
+    return d.aoiError.fnError(d, "custom", {}, "Invalid JSON in options: " + err.message);
+  }
 
-    const appData = {
-        data: {
-            name: name,
-            type: SlashTypes[type] || type,
-            ...(type === "slash" ? { description: description?.addBrackets() } : {}),
-            defaultMemberPermissions: appPermissions.includes(undefined) ? null : appPermissions,
-            contexts: appContext,
-            integrationTypes: appIntegrationType,
-            options: options ? JSON.parse(options) : []
-        },
-        guildID: guild?.id
-    };
+  const appData = {
+    data: {
+      name: name,
+      type: SlashTypes[type] || type,
+      ...(type === "slash" ? {
+        description: description?.addBrackets(),
+        ...("description_localizations" in parsedOptions ? { description_localizations: parsedOptions.description_localizations } : {}),
+        ...("name_localizations" in parsedOptions ? { name_localizations: parsedOptions.name_localizations } : {})
+      } : {}),
+      defaultMemberPermissions: appPermissions.includes(undefined) ? null : appPermissions,
+      contexts: appContext,
+      integrationTypes: appIntegrationType,
+      options: parsedOptions.options || []
+    },
+    guildID: guild?.id
+  };
 
-    await d.client.application.commands.create(appData.data, appData.guildID).catch((e) => {
-        d.aoiError.fnError(d, "custom", {}, "Failed To Create Application Command With Reason: " + e);
-    });
+  await d.client.application.commands.create(appData.data, appData.guildID).catch((e) => {
+    d.aoiError.fnError(d, "custom", {}, "Failed To Create Application Command With Reason: " + e);
+  });
 
-    return {
-        code: d.util.setCode(data)
-    };
+  return {
+    code: d.util.setCode(data)
+  };
 };


### PR DESCRIPTION
# Description

This PR adds support for localization of slash command names and descriptions (name_localizations, description_localizations) to the $createApplicationCommand function in Aoi.js. It allows command definitions to be automatically translated according to the user's Discord language.

---

# Type of Change

Please check all that apply:

[x] New feature (non-breaking change which adds functionality)

[ ] Bug fix (non-breaking change that fixes a bug)

[ ] Breaking change (causes existing functionality to break)

[x] This change requires a documentation update



---
# Checklist

[x] My code follows the style guidelines of this project

[x] Any dependent changes have been merged and published in downstream modules