### PR TITLE
fix: replace eval() with safe alternatives to prevent RCE

### DIFF
--- a/src/functions/condition/checkCondition.js
+++ b/src/functions/condition/checkCondition.js
@@ -2,6 +2,22 @@ const { CheckCondition } = require('../../core/CheckCondition.js')
 const { mustEscape } = require('../../core/mustEscape.js')
 
 /**
+ * CheckCondition.solve()の結果（true/false/&&/||/()のみ）を安全に評価する
+ * eval()を使わずにboolean式を解決する
+ */
+function safeEvalBoolean(expr) {
+    const sanitized = expr.replace(/\s/g, "");
+    // true, false, &&, ||, (, ) のみ許可
+    if (!/^[truefals&|()]+$/.test(sanitized)) return undefined;
+
+    try {
+        return new Function('"use strict"; return (' + sanitized + ")")();
+    } catch {
+        return undefined;
+    }
+}
+
+/**
  * @param {import("..").Data} d
  */
 module.exports = async (d) => {
@@ -14,8 +30,9 @@ module.exports = async (d) => {
         return d.aoiError.fnError(d, "custom", data.inside, "Valid Operators Not Provided In");
     }
 
+    // セキュリティ: eval()の代わりに安全なboolean評価（RCE対策）
     let result = CheckCondition.solve(mustEscape(condition) || "");
-    result = eval(result)?.toString();
+    result = safeEvalBoolean(result)?.toString();
 
     if (!["true", "false"].includes(result)) {
         d.aoiError.fnError(d, "custom", data.inside, "Invalid Condition Provided In");

--- a/src/functions/condition/checkCondition.js
+++ b/src/functions/condition/checkCondition.js
@@ -7,7 +7,7 @@ const { mustEscape } = require('../../core/mustEscape.js')
  */
 function safeEvalBoolean(expr) {
     const sanitized = expr.replace(/\s/g, "");
-    // true, false, &&, ||, (, ) のみ許可
+    // Only allow: true, false, &&, ||, (, )
     if (!/^[truefals&|()]+$/.test(sanitized)) return undefined;
 
     try {
@@ -30,7 +30,7 @@ module.exports = async (d) => {
         return d.aoiError.fnError(d, "custom", data.inside, "Valid Operators Not Provided In");
     }
 
-    // セキュリティ: eval()の代わりに安全なboolean評価（RCE対策）
+    // Security: safe boolean evaluation instead of eval() to prevent RCE
     let result = CheckCondition.solve(mustEscape(condition) || "");
     result = safeEvalBoolean(result)?.toString();
 

--- a/src/functions/condition/onlyIf.js
+++ b/src/functions/condition/onlyIf.js
@@ -2,6 +2,22 @@ const {CheckCondition} = require("../../core/CheckCondition.js");
 const {mustEscape} = require("../../core/mustEscape.js");
 
 /**
+ * CheckCondition.solve()の結果（true/false/&&/||/()のみ）を安全に評価する
+ * eval()を使わずにboolean式を解決する
+ */
+function safeEvalBoolean(expr) {
+    const sanitized = expr.replace(/\s/g, "");
+    // true, false, &&, ||, (, ) のみ許可
+    if (!/^[truefals&|()]+$/.test(sanitized)) return undefined;
+
+    try {
+        return new Function('"use strict"; return (' + sanitized + ")")();
+    } catch {
+        return undefined;
+    }
+}
+
+/**
  * @param {import("..").Data} d
  */
 module.exports = async (d) => {
@@ -11,7 +27,8 @@ module.exports = async (d) => {
 
     const [condition, err = ''] = data.inside.splits;
 
-    if (!eval(CheckCondition.solve(mustEscape(condition)))) {
+    // セキュリティ: eval()の代わりに安全なboolean評価（RCE対策）
+    if (!safeEvalBoolean(CheckCondition.solve(mustEscape(condition)))) {
         error = true;
         if (err?.trim() === "") {
         } else {

--- a/src/functions/condition/onlyIf.js
+++ b/src/functions/condition/onlyIf.js
@@ -7,7 +7,7 @@ const {mustEscape} = require("../../core/mustEscape.js");
  */
 function safeEvalBoolean(expr) {
     const sanitized = expr.replace(/\s/g, "");
-    // true, false, &&, ||, (, ) のみ許可
+    // Only allow: true, false, &&, ||, (, )
     if (!/^[truefals&|()]+$/.test(sanitized)) return undefined;
 
     try {
@@ -27,7 +27,7 @@ module.exports = async (d) => {
 
     const [condition, err = ''] = data.inside.splits;
 
-    // セキュリティ: eval()の代わりに安全なboolean評価（RCE対策）
+    // Security: safe boolean evaluation instead of eval() to prevent RCE
     if (!safeEvalBoolean(CheckCondition.solve(mustEscape(condition)))) {
         error = true;
         if (err?.trim() === "") {

--- a/src/functions/math/math.js
+++ b/src/functions/math/math.js
@@ -15,7 +15,7 @@ module.exports = async (d) => {
         return d.aoiError.fnError(d, "custom", { inside: data.inside }, "Invalid math expression");
     }
 
-    // セキュリティ: 安全な数式文字のみ許可（eval RCE対策）
+    // Security: only allow safe math expression characters to prevent RCE
     const safeExpr = math.replace(/\s/g, "");
     if (!/^[0-9+\-*/%.(),eEMath a-z_]+$/i.test(safeExpr)) {
         return d.aoiError.fnError(d, "custom", { inside: data.inside }, "Invalid math expression");

--- a/src/functions/math/math.js
+++ b/src/functions/math/math.js
@@ -15,7 +15,17 @@ module.exports = async (d) => {
         return d.aoiError.fnError(d, "custom", { inside: data.inside }, "Invalid math expression");
     }
 
-    data.result = eval(math);
+    // セキュリティ: 安全な数式文字のみ許可（eval RCE対策）
+    const safeExpr = math.replace(/\s/g, "");
+    if (!/^[0-9+\-*/%.(),eEMath a-z_]+$/i.test(safeExpr)) {
+        return d.aoiError.fnError(d, "custom", { inside: data.inside }, "Invalid math expression");
+    }
+
+    try {
+        data.result = new Function('"use strict"; return (' + math + ")")();
+    } catch {
+        return d.aoiError.fnError(d, "custom", { inside: data.inside }, "Invalid math expression");
+    }
 
     return {
         code: d.util.setCode(data)

--- a/src/functions/misc/findInCache.js
+++ b/src/functions/misc/findInCache.js
@@ -1,4 +1,27 @@
 /**
+ * 安全なプロパティアクセス（eval RCE対策）
+ */
+function safeGet(obj, path) {
+    if (!path || path.trim() === "") return obj;
+    return path.replace(/^\??\./, "").split(".").filter(Boolean).reduce((o, k) => o?.[k], obj);
+}
+
+/**
+ * 比較演算を安全に実行する
+ */
+function safeCompare(a, b, op) {
+    switch (op) {
+        case "===": return a === b;
+        case "==": return a == b;
+        case ">=": return a >= b;
+        case "<=": return a <= b;
+        case ">": return a > b;
+        case "<": return a < b;
+        default: return false;
+    }
+}
+
+/**
  * @param {import("..").Data} d
  */
 module.exports = async (d) => {
@@ -7,7 +30,6 @@ module.exports = async (d) => {
 
     let [type, name, prop, value, findType = "===", returnValue = "$default"] =
         data.inside.splits;
-    prop = prop.trim() === "" ? "" : "?." + prop;
 
     findType = ["includes", "startsWith", "endsWith"].includes(findType)
         ? findType
@@ -20,28 +42,27 @@ module.exports = async (d) => {
                 "Invalid FindType Provided In",
             );
     try {
+        // セキュリティ: eval()の代わりに安全なキャッシュ検索（RCE対策）
+        const cache = d.client.cacheManager.caches[type]?.[name];
+
         if (["includes", "startsWith", "endsWith"].includes(findType)) {
-            data.result = eval(
-                `d.client.cacheManager.caches[type][name].find(x => (prop.trim() === "" ? x : x${prop})[findType]("${value}"))`,
-            );
-
-            data.result =
-                typeof data.result === "object"
-                    ? returnValue === "$default"
-                        ? JSON.stringify(data.result, null, 2)
-                        : eval(`data.result?.${returnValue}`)
-                    : data.result;
+            data.result = cache?.find(x => {
+                const target = prop.trim() === "" ? x : safeGet(x, prop);
+                return typeof target?.[findType] === "function" && target[findType](value);
+            });
         } else {
-            data.result =
-                eval(`d.client.cacheManager.caches[type][name].find(x => (prop.trim() === "" ? x : x${prop}) ${findType} "${value}")`);
-
-            data.result =
-                typeof data.result === "object"
-                    ? returnValue === "$default"
-                        ? JSON.stringify(data.result, null, 2)
-                        : eval(`data.result?.${returnValue}`)
-                    : data.result;
+            data.result = cache?.find(x => {
+                const target = prop.trim() === "" ? x : safeGet(x, prop);
+                return safeCompare(target, value, findType);
+            });
         }
+
+        data.result =
+            typeof data.result === "object"
+                ? returnValue === "$default"
+                    ? JSON.stringify(data.result, null, 2)
+                    : safeGet(data.result, returnValue)
+                : data.result;
     } catch (e) {
         console.error(e);
         data.result = "";

--- a/src/functions/misc/findInCache.js
+++ b/src/functions/misc/findInCache.js
@@ -42,7 +42,7 @@ module.exports = async (d) => {
                 "Invalid FindType Provided In",
             );
     try {
-        // セキュリティ: eval()の代わりに安全なキャッシュ検索（RCE対策）
+        // Security: safe cache lookup instead of eval() to prevent RCE
         const cache = d.client.cacheManager.caches[type]?.[name];
 
         if (["includes", "startsWith", "endsWith"].includes(findType)) {

--- a/src/functions/misc/getObjectProperty.js
+++ b/src/functions/misc/getObjectProperty.js
@@ -10,7 +10,7 @@ module.exports = (d) => {
     const object = d.data.objects?.[objectName];
     if (!object) return d.aoiError.fnError("Object not found");
 
-    // セキュリティ: eval()の代わりに安全なプロパティアクセス（RCE対策）
+    // Security: safe property access instead of eval() to prevent RCE
     try {
         const keys = option
             .replace(/\[["']?/g, ".")

--- a/src/functions/misc/getObjectProperty.js
+++ b/src/functions/misc/getObjectProperty.js
@@ -10,12 +10,14 @@ module.exports = (d) => {
     const object = d.data.objects?.[objectName];
     if (!object) return d.aoiError.fnError("Object not found");
 
+    // セキュリティ: eval()の代わりに安全なプロパティアクセス（RCE対策）
     try {
-        if (option.startsWith("[")) {
-            data.result = eval(`object${option}`);
-        } else {
-            data.result = eval(`object.${option}`);
-        }
+        const keys = option
+            .replace(/\[["']?/g, ".")
+            .replace(/["']?\]/g, "")
+            .split(".")
+            .filter(Boolean);
+        data.result = keys.reduce((obj, key) => obj?.[key], object);
     } catch (e) {
         data.result = "undefined";
     }


### PR DESCRIPTION
## Summary

- **Critical security fix**: Remove all `eval()` calls that process user-controlled input from Discord messages, preventing Remote Code Execution (RCE) attacks
- **`$math` function** (`src/functions/math/math.js`): Replace `eval(math)` with input validation (allowlist regex for safe math characters) + `new Function()` in strict mode
- **`$getObjectProperty`** (`src/functions/misc/getObjectProperty.js`): Replace `eval('object.' + option)` with safe property traversal using `split('.')` + `reduce()`
- **`$checkCondition`** (`src/functions/condition/checkCondition.js`): Replace `eval(result)` with a `safeEvalBoolean()` function that only allows `true`, `false`, `&&`, `||`, and parentheses
- **`$onlyIf`** (`src/functions/condition/onlyIf.js`): Same `safeEvalBoolean()` fix as checkCondition
- **`$findInCache`** (`src/functions/misc/findInCache.js`): Replace all 4 `eval()` calls with direct function calls using safe property access helpers and explicit comparison operators

### Attack vector

A Discord user could craft a message like `$math[require('child_process').execSync('rm -rf /')]` which would execute arbitrary system commands on the bot's host machine. The regex allowlist only replaced known math function names but did not block arbitrary JavaScript.

## Test plan

- [ ] Verify `$math[1+2*3]` still returns `7`
- [ ] Verify `$math[sqrt(16)]` still returns `4`
- [ ] Verify `$math[PI*2]` still returns `6.283...`
- [ ] Verify `$math[require('fs')]` returns an error instead of executing
- [ ] Verify `$getObjectProperty` still traverses nested objects (e.g., `a.b.c` and `a["b"]`)
- [ ] Verify `$checkCondition[1==1]` returns `true`
- [ ] Verify `$checkCondition[hello==hello&&1>0]` returns `true`
- [ ] Verify `$onlyIf` correctly evaluates conditions and triggers error messages
- [ ] Verify `$findInCache` with string methods (includes/startsWith/endsWith) and comparison operators